### PR TITLE
Add ability to build the blot_met target

### DIFF
--- a/packages/seacas/applications/blot/CMakeLists.txt
+++ b/packages/seacas/applications/blot/CMakeLists.txt
@@ -42,4 +42,11 @@ TRIBITS_ADD_EXECUTABLE(blot_cps NOEXEPREFIX NOEXESUFFIX
 			        COMM serial mpi)
 install_executable(blot_cps)
 
+TRIBITS_ADD_EXECUTABLE(blot_met NOEXEPREFIX NOEXESUFFIX
+				LINKER_LANGUAGE Fortran
+			        SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/blot.f
+					${CMAKE_CURRENT_SOURCE_DIR}/cgi/vdicps.f
+			        COMM serial mpi)
+install_executable(blot_met)
+
 TRIBITS_SUBPACKAGE_POSTPROCESS()

--- a/packages/seacas/scripts/blot.in
+++ b/packages/seacas/scripts/blot.in
@@ -28,7 +28,7 @@ exit 1
 
 function show_device {
  echo " "
- tempA=`find ${ACCESS}/bin -name ${codename}.\* |grep -v ${codename}.o |sed -e s:${ACCESS}/bin/${codename}.::`
+ tempA=`find ${ACCESS}/bin -name ${codename}${sep}\* |grep -v ${codename}.o |sed -e s:${ACCESS}/bin/${codename}${sep}::`
  echo "Standard options for 'device':" 
  echo "${txtgrn}" $tempA "${txtrst}"
  echo " "


### PR DESCRIPTION
re?-add ability to build the blot_met target (not sure when this stopped happening).
Also added a small fix to the blot.in script file. Blot was not detecting the switch from blot.x11 to blot_x11 correctly due to a separator change.
