### PR TITLE
Remove redundant TriBITS includes

### DIFF
--- a/packages/seacas/CMakeLists.txt
+++ b/packages/seacas/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsPackageMacros)
-INCLUDE(TribitsAddOptionAndDefine)
 
 #
 # A) Define the package

--- a/packages/seacas/applications/algebra/CMakeLists.txt
+++ b/packages/seacas/applications/algebra/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Algebra)

--- a/packages/seacas/applications/aprepro/CMakeLists.txt
+++ b/packages/seacas/applications/aprepro/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Aprepro)
 

--- a/packages/seacas/applications/blot/CMakeLists.txt
+++ b/packages/seacas/applications/blot/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Blot)

--- a/packages/seacas/applications/conjoin/CMakeLists.txt
+++ b/packages/seacas/applications/conjoin/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Conjoin)
 

--- a/packages/seacas/applications/ejoin/CMakeLists.txt
+++ b/packages/seacas/applications/ejoin/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Ejoin)
 

--- a/packages/seacas/applications/epu/CMakeLists.txt
+++ b/packages/seacas/applications/epu/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Epu)
 

--- a/packages/seacas/applications/ex1ex2v2/CMakeLists.txt
+++ b/packages/seacas/applications/ex1ex2v2/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Ex1ex2v2)

--- a/packages/seacas/applications/ex2ex1v2/CMakeLists.txt
+++ b/packages/seacas/applications/ex2ex1v2/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Ex2ex1v2)

--- a/packages/seacas/applications/exo2mat/CMakeLists.txt
+++ b/packages/seacas/applications/exo2mat/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 
 IF (TPL_ENABLE_Matio)
 TRIBITS_SUBPACKAGE(Exo2mat)

--- a/packages/seacas/applications/exo_format/CMakeLists.txt
+++ b/packages/seacas/applications/exo_format/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Exo_format)
 

--- a/packages/seacas/applications/exodiff/CMakeLists.txt
+++ b/packages/seacas/applications/exodiff/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 
 TRIBITS_SUBPACKAGE(Exodiff)
 

--- a/packages/seacas/applications/exomatlab/CMakeLists.txt
+++ b/packages/seacas/applications/exomatlab/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Exomatlab)
 

--- a/packages/seacas/applications/exotec2/CMakeLists.txt
+++ b/packages/seacas/applications/exotec2/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 
 SEACAS_PACKAGE(Exotec2)
 

--- a/packages/seacas/applications/exotxt/CMakeLists.txt
+++ b/packages/seacas/applications/exotxt/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Exotxt)

--- a/packages/seacas/applications/fastq/CMakeLists.txt
+++ b/packages/seacas/applications/fastq/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Fastq)

--- a/packages/seacas/applications/gen3d/CMakeLists.txt
+++ b/packages/seacas/applications/gen3d/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Gen3D)

--- a/packages/seacas/applications/genshell/CMakeLists.txt
+++ b/packages/seacas/applications/genshell/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Genshell)

--- a/packages/seacas/applications/gjoin/CMakeLists.txt
+++ b/packages/seacas/applications/gjoin/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Gjoin)

--- a/packages/seacas/applications/grepos/CMakeLists.txt
+++ b/packages/seacas/applications/grepos/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Grepos)

--- a/packages/seacas/applications/grope/CMakeLists.txt
+++ b/packages/seacas/applications/grope/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Grope)

--- a/packages/seacas/applications/mapvar-kd/CMakeLists.txt
+++ b/packages/seacas/applications/mapvar-kd/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Mapvar-kd)

--- a/packages/seacas/applications/mapvar/CMakeLists.txt
+++ b/packages/seacas/applications/mapvar/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Mapvar)

--- a/packages/seacas/applications/mat2exo/CMakeLists.txt
+++ b/packages/seacas/applications/mat2exo/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 
 IF (TPL_ENABLE_Matio)
 TRIBITS_SUBPACKAGE(Mat2exo)

--- a/packages/seacas/applications/nem_slice/CMakeLists.txt
+++ b/packages/seacas/applications/nem_slice/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 INCLUDE(CheckIncludeFile)
 
 TRIBITS_SUBPACKAGE(Nemslice)

--- a/packages/seacas/applications/nem_spread/CMakeLists.txt
+++ b/packages/seacas/applications/nem_spread/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Nemspread)
 

--- a/packages/seacas/applications/numbers/CMakeLists.txt
+++ b/packages/seacas/applications/numbers/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Numbers)

--- a/packages/seacas/applications/txtexo/CMakeLists.txt
+++ b/packages/seacas/applications/txtexo/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsAddExecutable)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Txtexo)

--- a/packages/seacas/libraries/aprepro_lib/CMakeLists.txt
+++ b/packages/seacas/libraries/aprepro_lib/CMakeLists.txt
@@ -1,8 +1,6 @@
 
 option(USE_TRIBITS "Use the Tribits modules to build Aprepro" ON)
 if(USE_TRIBITS)
-  INCLUDE(TribitsSubPackageMacros)
-  INCLUDE(TribitsLibraryMacros)
 
   TRIBITS_SUBPACKAGE(Aprepro_lib)
 endif()

--- a/packages/seacas/libraries/chaco/CMakeLists.txt
+++ b/packages/seacas/libraries/chaco/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Chaco)
 

--- a/packages/seacas/libraries/exoIIv2for32/CMakeLists.txt
+++ b/packages/seacas/libraries/exoIIv2for32/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(ExoIIv2for32)

--- a/packages/seacas/libraries/exoIIv2for32/test/CMakeLists.txt
+++ b/packages/seacas/libraries/exoIIv2for32/test/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsAddTest)
-INCLUDE(TribitsAddAdvancedTest)
 
 ADD_DEFINITIONS(-DUSING_CMAKE)
 

--- a/packages/seacas/libraries/exodus/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
 TRIBITS_SUBPACKAGE(Exodus)
 
 if (${CMAKE_PROJECT_NAME} STREQUAL "SEACASProj")

--- a/packages/seacas/libraries/exodus/test/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus/test/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsAddTest)
-INCLUDE(TribitsAddAdvancedTest)
 
 ADD_DEFINITIONS(-DUSING_CMAKE)
 

--- a/packages/seacas/libraries/exodus_for/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus_for/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Exodus_for)

--- a/packages/seacas/libraries/exodus_for/test/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus_for/test/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsAddTest)
-INCLUDE(TribitsAddAdvancedTest)
 
 ADD_DEFINITIONS(-DUSING_CMAKE)
 

--- a/packages/seacas/libraries/ioss/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
 
 TRIBITS_SUBPACKAGE(Ioss)
 

--- a/packages/seacas/libraries/ioss/src/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_CONFIGURE_FILE(${PACKAGE_NAME}_config.h)
 

--- a/packages/seacas/libraries/ioss/src/cgns/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/cgns/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/exo_fac/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/exo_fac/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/exo_fpp/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/exo_fpp/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/exo_par/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/exo_par/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/exodus/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/exodus/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/generated/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/generated/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/heartbeat/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/heartbeat/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/init/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/init/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/main/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/main/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
-INCLUDE(TribitsAddExecutable)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/pamgen/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/pamgen/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/transform/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/transform/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/utest/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/utest/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsAddExecutableAndTest)
 
 TRIBITS_ADD_EXECUTABLE(
  Utst_ioel

--- a/packages/seacas/libraries/ioss/src/visualization/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/visualization/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/ioss/src/xdmf/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/xdmf/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 SET(HEADERS "")
 SET(SOURCES "")

--- a/packages/seacas/libraries/mapvarlib/CMakeLists.txt
+++ b/packages/seacas/libraries/mapvarlib/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Mapvarlib)

--- a/packages/seacas/libraries/nemesis/CMakeLists.txt
+++ b/packages/seacas/libraries/nemesis/CMakeLists.txt
@@ -1,6 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
-INCLUDE(TribitsAddExecutableAndTest)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(Nemesis)

--- a/packages/seacas/libraries/plt/CMakeLists.txt
+++ b/packages/seacas/libraries/plt/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(PLT)

--- a/packages/seacas/libraries/supes/CMakeLists.txt
+++ b/packages/seacas/libraries/supes/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Supes)
 

--- a/packages/seacas/libraries/suplib/CMakeLists.txt
+++ b/packages/seacas/libraries/suplib/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(Suplib)
 INCLUDE(FortranSettings)

--- a/packages/seacas/libraries/suplib_c/CMakeLists.txt
+++ b/packages/seacas/libraries/suplib_c/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(SuplibC)
 

--- a/packages/seacas/libraries/suplib_cpp/CMakeLists.txt
+++ b/packages/seacas/libraries/suplib_cpp/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(TribitsLibraryMacros)
 
 TRIBITS_SUBPACKAGE(SuplibCpp)
 

--- a/packages/seacas/libraries/svdi/CMakeLists.txt
+++ b/packages/seacas/libraries/svdi/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsSubPackageMacros)
-INCLUDE(TribitsLibraryMacros)
 INCLUDE(FortranSettings)
 
 TRIBITS_SUBPACKAGE(SVDI)

--- a/packages/seacas/scripts/CMakeLists.txt
+++ b/packages/seacas/scripts/CMakeLists.txt
@@ -1,5 +1,3 @@
-INCLUDE(TribitsAddExecutable)
-INCLUDE(TribitsLibraryMacros)
 
 SET( ACCESSDIR ${CMAKE_INSTALL_PREFIX} )
 SET( SEPARATOR "_")


### PR DESCRIPTION
A long time ago, TriBITS added all of the necessary includes in TriBITS.cmake
to avoid needing to have the project, repostory, and packages *.cmake and
CMakeLists.txt files from needing to include many of the TriBITS *.cmake
module files (see TriBITSPub/TriBITS#18).

This commit was created by running the script:

  TriBITS/refactoring/remove_std_tribits_includes_r.sh

Accepting this PR will take care of trilinos/Trilinos#489 for SEACAS once SEACAS is synced again back into Trilinos (by the indirect route that it currently takes).
