### PR TITLE
This fixes Blot and Fastq printing Successful Execution when exiting with error

### DIFF
--- a/packages/seacas/scripts/blot
+++ b/packages/seacas/scripts/blot
@@ -225,7 +225,10 @@ fi
 abspath ${FOR011}
 
 # Run the code, --
-${ACCESSBIN}/${codename}_${device} ${ps_option} ${nomap_option} ${caption} -basename ${filename} ${FOR011}
+if ${ACCESSBIN}/${codename}_${device} ${ps_option} ${nomap_option} ${caption} -basename ${filename} ${FOR011}
+then
+  echo "${txtgrn}BLOT Successful Execution${txtrst}"
+fi
 
 if [ ! -z ${filename} ] && [ "${device}" != "dual" ] && [ "${device}" != "xcps" ]
 then
@@ -238,4 +241,3 @@ fi
 # Remove temporary files
 if [ -e Blot.90.$$ ] ; then rm -f Blot.90.$$ ; fi
 
-echo "${txtgrn}BLOT Successful Execution${txtrst}"

--- a/packages/seacas/scripts/blot.in
+++ b/packages/seacas/scripts/blot.in
@@ -194,7 +194,10 @@ fi
 abspath ${FOR011}
 
 # Run the code
-${ACCESS}/bin/${codename}${sep}${device} ${ps_option} ${nomap_option} ${caption} -basename ${filename} ${FOR011}
+if ${ACCESS}/bin/${codename}${sep}${device} ${ps_option} ${nomap_option} ${caption} -basename ${filename} ${FOR011}
+then
+  echo "${txtgrn}BLOT Successful Execution${txtrst}"
+fi
 
 if [ ! -z ${filename} ] && [ "${device}" != "dual" ] && [ "${device}" != "xcps" ]
 then
@@ -207,4 +210,3 @@ fi
 # Remove temporary files
 if [ -e Blot.90.$$ ] ; then rm -f Blot.90.$$ ; fi
 
-echo "${txtgrn}BLOT Successful Execution${txtrst}"

--- a/packages/seacas/scripts/fastq
+++ b/packages/seacas/scripts/fastq
@@ -209,7 +209,10 @@ then
 fi
 
 # Run the code, --
-${ACCESSBIN}/${codename}_${device} -basename ${filename} 
+if ${ACCESSBIN}/${codename}_${device} -basename ${filename}
+then
+  echo "${txtgrn}BLOT Successful Execution${txtrst}"
+fi
 
 if [ ! -z ${filename} ] && [ "${device}" != "dual" ] && [ "${device}" != "xcps" ]
 then
@@ -223,4 +226,3 @@ if [ "${aprepro}" == "file" ] ; then
     rm -f ${FOR001}
 fi
 
-echo "${txtgrn}FASTQ Successful Execution${txtrst}"

--- a/packages/seacas/scripts/fastq.in
+++ b/packages/seacas/scripts/fastq.in
@@ -177,7 +177,10 @@ then
 fi
 
 # Run the code, --
-${ACCESS}/bin/${codename}${sep}${device} -basename ${filename} 
+if ${ACCESS}/bin/${codename}${sep}${device} -basename ${filename}
+then
+  echo "${txtgrn}BLOT Successful Execution${txtrst}"
+fi
 
 if [ ! -z ${filename} ] && [ "${device}" != "dual" ] && [ "${device}" != "xcps" ]
 then
@@ -191,4 +194,3 @@ if [ "${aprepro}" == "file" ] ; then
     rm -f ${FOR001}
 fi
 
-echo "${txtgrn}FASTQ Successful Execution${txtrst}"


### PR DESCRIPTION
When using Fastq interactively, I was mildly annoyed by segfaults printing "Fastq Successful Execution," so I changed the script's behavior to only display that message when these programs exit with code zero. This happens when Fastq is exited with ex and when Blot is exited with exi, qui, or end.

If printing this message on an error is intentional behavior feel free to discard this PR though.