### PR TITLE
Update ex_copy.c

### DIFF
--- a/packages/seacas/libraries/exodus/src/ex_copy.c
+++ b/packages/seacas/libraries/exodus/src/ex_copy.c
@@ -798,8 +798,8 @@ int cpy_coord_val(int in_id, int out_id, char *var_nm, int in_large)
   EXCHECKI(nc_inq_varid(in_id, VAR_COORD, &var_in_id));
 
   EXCHECKI(nc_inq_varid(out_id, VAR_COORD_X, &var_out_id[0]));
-  EXCHECKI(nc_inq_varid(out_id, VAR_COORD_Y, &var_out_id[1]));
-  EXCHECKI(nc_inq_varid(out_id, VAR_COORD_Z, &var_out_id[2]));
+  if (spatial_dim > 1) EXCHECKI(nc_inq_varid(out_id, VAR_COORD_Y, &var_out_id[1]));
+  if (spatial_dim > 2) EXCHECKI(nc_inq_varid(out_id, VAR_COORD_Z, &var_out_id[2]));
 
   EXCHECKI(nc_inq_vartype(in_id, var_in_id, &var_type_in));
   EXCHECKI(nc_inq_vartype(out_id, var_out_id[0], &var_type_out));


### PR DESCRIPTION
copying a 2D normal model fails right now as coord_z is not defined in the output file.
This patch fixes this issue