### PR TITLE
Add numeric header (absence broke Intel compile)

### DIFF
--- a/packages/seacas/applications/ejoin/EJ_mapping.C
+++ b/packages/seacas/applications/ejoin/EJ_mapping.C
@@ -41,6 +41,7 @@
 #include <iostream>              // for operator<<, basic_ostream, etc
 #include <smart_assert.h>        // for SMART_ASSERT
 #include <utility>               // for make_pair, pair
+#include <numeric>
 
 namespace {
   bool entity_is_omitted(Ioss::GroupingEntity *block)


### PR DESCRIPTION
Without <numeric>, breakage was: No itoa in namespace std (Intel compiler; icpc (ICC) 17.0.4 20170411)