### PR TITLE
exodus: support older Visual Studio compilers

### DIFF
--- a/packages/seacas/libraries/exodus/include/exodusII_int.h
+++ b/packages/seacas/libraries/exodus/include/exodusII_int.h
@@ -77,6 +77,11 @@
 
 #include <stdio.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define __func__ __FUNCTION__
+#define snprintf _snprintf
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Visual Studio 2013 only supports `__func__` in C++ code and `snprintf`
is available as `_snprintf`.