### PR TITLE
Workaround for ninja+cuda rebuild problems in Trilinos (#97)

### DIFF
--- a/packages/seacas/libraries/aprepro_lib/apr_scanner.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_scanner.cc
@@ -971,7 +971,6 @@ static yyconst flex_int16_t yy_rule_linenum[102] = {
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-#line 1 "/scratch/gdsjaar/seacas/packages/seacas/libraries/aprepro_lib/aprepro.ll"
 /* -*- Mode: c++ -*- */
 /*
  * Copyright (c) 2014-2017 National Technology & Engineering Solutions


### PR DESCRIPTION
This addressed #97 with a short-term fix (until the next time these files are regenerated).

This remove the line starting wtih '#line 1' which causes nvcc to create a
wrong dependency on apr_scanner.o based on the non-existant file
/scratch/gdsjaar/seacas/packages/seacas/libraries/aprepro_lib/aprepro.ll.  See
trilinos/Trilinos#2359.

This is the same patch as the Trilinos patch in PR trilinos/Trilinos#2360.  By
making this patch here as well, the next time SEACAS is snapshotted into
Trilinos, it will not overwrite the patch in trilinos/Trilinos#2360 being
committed to Trilinos.

But the right solution will be to avoid lines starting with '#line 1' in the
future when generating these files.