### PR TITLE
Aprepro_lib: fix potential segfault in destructor

### DIFF
--- a/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
@@ -77,7 +77,7 @@ namespace SEAMS {
 
   Aprepro::~Aprepro()
   {
-    if ( outputStream.size() > 0) {
+    if (!outputStream.empty()) {
       outputStream.top()->flush();
     }
 
@@ -848,7 +848,7 @@ namespace SEAMS {
       history_data hist;
       hist.original     = original;
       hist.substitution = substitution;
-      hist.index        = outputStream.top()->tellp();
+      hist.index        = outputStream.empty() ? 0 : outputStream.top()->tellp();
 
       history.push_back(hist);
     }

--- a/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
@@ -77,7 +77,9 @@ namespace SEAMS {
 
   Aprepro::~Aprepro()
   {
-    outputStream.top()->flush();
+    if ( outputStream.size() > 0) {
+      outputStream.top()->flush();
+    }
 
     if ((stringScanner != nullptr) && stringScanner != lexer) {
       delete stringScanner;

--- a/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
@@ -848,7 +848,7 @@ namespace SEAMS {
       history_data hist;
       hist.original     = original;
       hist.substitution = substitution;
-      hist.index        = outputStream.empty() ? 0 : outputStream.top()->tellp();
+      hist.index        = outputStream.empty() ? std::streampos(0) : outputStream.top()->tellp();
 
       history.push_back(hist);
     }


### PR DESCRIPTION
Issue #120

In certain usages of the Aprepro class the outputStream stack might
have no elements in it so calling flush on the top element segfaults.

The fix is to check that outputStream has > 0 elements.