### PR TITLE
Exodus fortran cmake bug fix

### DIFF
--- a/packages/seacas/libraries/exodus_for/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus_for/CMakeLists.txt
@@ -1,4 +1,5 @@
 INCLUDE(FortranSettings)
+INCLUDE(InstallSymlink)
 
 TRIBITS_SUBPACKAGE(Exodus_for)
 


### PR DESCRIPTION
When compiling Exodus Fortran libraries, the following error is thrown:

    CMake Error at packages/seacas/libraries/exodus_for/CMakeLists.txt:37 (InstallSymLink):
      Unknown CMake command "InstallSymLink".

This minor patch fixes this.