### PR TITLE
exodusII_int: use inttypes.h for VS2015 and newer

### DIFF
--- a/packages/seacas/libraries/exodus/include/exodusII_int.h
+++ b/packages/seacas/libraries/exodus/include/exodusII_int.h
@@ -52,7 +52,7 @@
 #include "netcdf_meta.h"
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(_MSC_VER) && _MSC_VER < 1900
 #define PRId64 "I64d"
 #else
 #include <inttypes.h>


### PR DESCRIPTION
`PRId64` is now provided by VS2015 and causes warnings about
redefinition if done here.