### PR TITLE
Include cstdint

### DIFF
--- a/packages/seacas/applications/exodiff/iqsort.C
+++ b/packages/seacas/applications/exodiff/iqsort.C
@@ -31,6 +31,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 #include "iqsort.h"
+#include <cstdint>
 #include <fmt/ostream.h>
 
 namespace {


### PR DESCRIPTION
Otherwise on alpine linux, using gcc 8.3.0, I get
```
[...]/iqsort.C:170:33: error: 'int64_t' does not name a type
 template void index_qsort(const int64_t v[], int64_t iv[], size_t N);
                                 ^~~~~~~
[...]/iqsort.C:170:46: error: 'int64_t' has not been declared
 template void index_qsort(const int64_t v[], int64_t iv[], size_t N);
                                              ^~~~~~~
[...]/iqsort.C:170:68: error: duplicate explicit instantiation of 'void index_qsort(const T*, INT*, size_t) [with T = int; INT = int; size_t = long unsigned int]' [-fpermissive]
 template void index_qsort(const int64_t v[], int64_t iv[], size_t N);
                                                                    ^
[..]/iqsort.C:171:45: error: 'int64_t' has not been declared
 template void index_qsort(const double v[], int64_t iv[], size_t N);
                                             ^~~~~~~
[...]/qsort.C:171:67: error: duplicate explicit instantiation of 'void index_qsort(const T*, INT*, size_t) [with T = double; INT = int; size_t = long unsigned int]' [-fpermissive]
 template void index_qsort(const double v[], int64_t iv[], size_t N);
                                                                   ^
make[5]: *** [packages/seacas/applications/exodiff/CMakeFiles/exodiff.dir/build.make:180: packages/seacas/applications/exodiff/CMakeFiles/exodiff.dir/iqsort.C.o] Error 1
make[5]: *** Waiting for unfinished jobs....
make[4]: *** [CMakeFiles/Makefile2:3617: packages/seacas/applications/exodiff/CMakeFiles/exodiff.dir/all] Error 2
make[4]: *** Waiting for unfinished jobs....
make[3]: *** [Makefile:163: all] Error 2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gsjaardema/seacas/148)
<!-- Reviewable:end -->
