### PR TITLE
SEACAS: Allow for disable of explore exe (trilinos/Trilinos#6008)

### DIFF
--- a/packages/seacas/applications/explore/CMakeLists.txt
+++ b/packages/seacas/applications/explore/CMakeLists.txt
@@ -20,13 +20,17 @@ TRIBITS_ADD_EXECUTABLE(
   LINKER_LANGUAGE Fortran
   SOURCES ${SOURCES}
   COMM serial mpi
+  ADDED_EXE_TARGET_NAME_OUT explore_added
   )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "SEACASProj")
-InstallSymLink(explore ${CMAKE_INSTALL_PREFIX}/bin/grope)
+if (explore_added)
+
+  if (${CMAKE_PROJECT_NAME} STREQUAL "SEACASProj")
+    InstallSymLink(explore ${CMAKE_INSTALL_PREFIX}/bin/grope)
+  endif()
+
+  install_executable(explore)
+
 endif()
 
-install_executable(explore)
-
 TRIBITS_SUBPACKAGE_POSTPROCESS()
-


### PR DESCRIPTION
Need to be able to disable the build of the SEACAS 'explore' executable for cuda+rdc builds for now with -Dexpore_EXE_DISABLE=ON (see trilinos/Trilinos#6008).

This matches the PR trilinos/Trilinos#6121 and must be merged here in the seacas github repo or the next snapshot to Triilnos will wipe out these changes.
