### PR TITLE
style: replace import * with calling each thing

### DIFF
--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -461,24 +461,24 @@ class ex_init_params(ctypes.Structure):
     num_elem_maps : int
         number of model elem maps
     """
-    _fields_ = [("title", c_char * (MAX_LINE_LENGTH + 1)),
-                ("num_dim", c_longlong),
-                ("num_nodes", c_longlong),
-                ("num_edge", c_longlong),
-                ("num_edge_blk", c_longlong),
-                ("num_face", c_longlong),
-                ("num_face_blk", c_longlong),
-                ("num_elem", c_longlong),
-                ("num_elem_blk", c_longlong),
-                ("num_node_sets", c_longlong),
-                ("num_edge_sets", c_longlong),
-                ("num_face_sets", c_longlong),
-                ("num_side_sets", c_longlong),
-                ("num_elem_sets", c_longlong),
-                ("num_node_maps", c_longlong),
-                ("num_edge_maps", c_longlong),
-                ("num_face_maps", c_longlong),
-                ("num_elem_maps", c_longlong)]
+    _fields_ = [("title", ctypes.c_char * (MAX_LINE_LENGTH + 1)),
+                ("num_dim", ctypes.c_longlong),
+                ("num_nodes", ctypes.c_longlong),
+                ("num_edge", ctypes.c_longlong),
+                ("num_edge_blk", ctypes.c_longlong),
+                ("num_face", ctypes.c_longlong),
+                ("num_face_blk", ctypes.c_longlong),
+                ("num_elem", ctypes.c_longlong),
+                ("num_elem_blk", ctypes.c_longlong),
+                ("num_node_sets", ctypes.c_longlong),
+                ("num_edge_sets", ctypes.c_longlong),
+                ("num_face_sets", ctypes.c_longlong),
+                ("num_side_sets", ctypes.c_longlong),
+                ("num_elem_sets", ctypes.c_longlong),
+                ("num_node_maps", ctypes.c_longlong),
+                ("num_edge_maps", ctypes.c_longlong),
+                ("num_face_maps", ctypes.c_longlong),
+                ("num_elem_maps", ctypes.c_longlong)]
 
 
 #
@@ -679,7 +679,7 @@ class exodus:
                   .format(p.title, MAX_LINE_LENGTH))
             p.title = p.title[-1*MAX_LINE_LENGTH:]
 
-        self.Title = create_string_buffer(p.title, MAX_LINE_LENGTH + 1)
+        self.Title = ctypes.create_string_buffer(p.title, MAX_LINE_LENGTH + 1)
         self.numDim = ctypes.c_longlong(p.num_dim)
         self.numNodes = ctypes.c_longlong(p.num_nodes)
         self.numElem = ctypes.c_longlong(p.num_elem)
@@ -687,7 +687,7 @@ class exodus:
         self.numNodeSets = ctypes.c_longlong(p.num_node_sets)
         self.numSideSets = ctypes.c_longlong(p.num_side_sets)
 
-        EXODUS_LIB.ex_put_init_ext(self.fileId, byref(p))
+        EXODUS_LIB.ex_put_init_ext(self.fileId, ctypes.byref(p))
         return True
 
 
@@ -712,8 +712,8 @@ class exodus:
         exo_copy : exodus object
         """
         fileId = EXODUS_LIB.ex_create_int(fileName.encode('ascii'), EX_NOCLOBBER,
-                                          byref(self.comp_ws),
-                                          byref(self.io_ws),
+                                          ctypes.byref(self.comp_ws),
+                                          ctypes.byref(self.io_ws),
                                           EX_API_VERSION_NODOT)
 
         i64Status = EXODUS_LIB.ex_int64_status(self.fileId)
@@ -971,7 +971,7 @@ class exodus:
         Returns
         -------
             if array_type == 'ctype' :
-              <list<c_double>>  time_vals
+              <list<ctypes.c_double>>  time_vals
 
             if array_type == 'numpy' :
               <np_array<double>>  time_vals
@@ -1086,9 +1086,9 @@ class exodus:
         -------
 
             if array_type == 'ctype':
-              <list<c_double>>  x_coords  global x-direction coordinates
-              <list<c_double>>  y_coords  global y-direction coordinates
-              <list<c_double>>  z_coords  global z-direction coordinates
+              <list<ctypes.c_double>>  x_coords  global x-direction coordinates
+              <list<ctypes.c_double>>  y_coords  global y-direction coordinates
+              <list<ctypes.c_double>>  z_coords  global z-direction coordinates
 
             if array_type == 'numpy':
               <np_array<double>>  x_coords  global x-direction coordinates
@@ -1482,7 +1482,7 @@ class exodus:
         -------
 
             if array_type == 'ctype':
-              <list<c_double>>  nvar_vals
+              <list<ctypes.c_double>>  nvar_vals
 
             if array_type == 'numpy':
               <np_array<double>>  nvar_vals
@@ -1609,7 +1609,7 @@ class exodus:
 
         Returns
         -------
-            <list<c_int>>  elem_id_map
+            <list<ctypes.c_int>>  elem_id_map
         """
         elemNumMap = self.__ex_get_elem_num_map()
         return elemNumMap
@@ -2220,7 +2220,7 @@ class exodus:
         -------
 
             if array_type == 'ctype':
-              <list<c_double>>  evar_vals
+              <list<ctypes.c_double>>  evar_vals
 
             if array_type == 'numpy':
               <np_array<double>>  evar_vals
@@ -2832,7 +2832,7 @@ class exodus:
         -------
 
             if array_type == 'ctype':
-              <list<c_double>>  nsvar_vals
+              <list<ctypes.c_double>>  nsvar_vals
 
             if array_type == 'numpy':
               <np_array<double>>  nsvar_vals
@@ -3556,7 +3556,7 @@ class exodus:
         -------
 
             if array_type == 'ctype':
-              <list<c_double>>  ssvar_vals
+              <list<ctypes.c_double>>  ssvar_vals
 
             if array_type == 'numpy':
               <np_array<double>>  ssvar_vals
@@ -3832,13 +3832,13 @@ class exodus:
         names = self.get_variable_names('EX_GLOBAL')
         # get all values
         numVals = self.get_variable_number('EX_GLOBAL')
-        values = (c_double * numVals)()
+        values = (ctypes.c_double * numVals)()
         for i in range(numVals):
-            values[i] = c_double(
+            values[i] = ctypes.c_double(
                 self.get_global_variable_value(
                     names[i], step))
         # adjust one of them
-        values[names.index(name)] = c_double(value)
+        values[names.index(name)] = ctypes.c_double(value)
         # write them all
         EXODUS_LIB.ex_put_var(self.fileId,
                               ctypes.c_int(step),
@@ -3867,9 +3867,9 @@ class exodus:
             True = successful execution
         """
         numVals = self.get_variable_number('EX_GLOBAL')
-        gvalues = (c_double * numVals)()
+        gvalues = (ctypes.c_double * numVals)()
         for i in range(numVals):
-            gvalues[i] = c_double(values[i])
+            gvalues[i] = ctypes.c_double(values[i])
         EXODUS_LIB.ex_put_glob_vars(self.fileId,
                                     ctypes.c_int(step),
                                     ctypes.c_int(numVals),
@@ -3936,7 +3936,7 @@ class exodus:
 
         ebType = ctypes.c_int(get_entity_type('EX_ELEM_BLOCK'))
         EXODUS_LIB.ex_put_block(self.fileId, ebType, ctypes.c_longlong(blkID),
-                                create_string_buffer(b"NFACED"),
+                                ctypes.create_string_buffer(b"NFACED"),
                                 ctypes.c_longlong(num_elems_this_blk),
                                 ctypes.c_longlong(0),
                                 ctypes.c_longlong(0),
@@ -3968,14 +3968,14 @@ class exodus:
         status : bool
             True = successful execution
         """
-        fbType = c_int(get_entity_type('EX_FACE_BLOCK'))
-        EXODUS_LIB.ex_put_block(self.fileId, fbType, c_longlong(blkID),
-                                create_string_buffer(b"NSIDED"),
-                                c_longlong(num_faces_this_blk),
-                                c_longlong(num_nodes),
-                                c_longlong(0),
-                                c_longlong(0),
-                                c_longlong(num_attr_per_face))
+        fbType = ctypes.c_int(get_entity_type('EX_FACE_BLOCK'))
+        EXODUS_LIB.ex_put_block(self.fileId, fbType, ctypes.c_longlong(blkID),
+                                ctypes.create_string_buffer(b"NSIDED"),
+                                ctypes.c_longlong(num_faces_this_blk),
+                                ctypes.c_longlong(num_nodes),
+                                ctypes.c_longlong(0),
+                                ctypes.c_longlong(0),
+                                ctypes.c_longlong(num_attr_per_face))
         return True
 
     # --------------------------------------------------------------------
@@ -4031,11 +4031,11 @@ class exodus:
         status : bool
             True = successful execution
         """
-        ebType = c_int(get_entity_type('EX_FACE_BLOCK'))
-        entity_counts = (c_int * len(entityCounts))()
+        ebType = ctypes.c_int(get_entity_type('EX_FACE_BLOCK'))
+        entity_counts = (ctypes.c_int * len(entityCounts))()
         entity_counts[:] = entityCounts
         EXODUS_LIB.ex_put_entity_count_per_polyhedra(
-            self.fileId, ebType, c_longlong(blkID), entity_counts)
+            self.fileId, ebType, ctypes.c_longlong(blkID), entity_counts)
         return True
 
     # --------------------------------------------------------------------
@@ -4061,10 +4061,10 @@ class exodus:
         status : bool
             True = successful execution
         """
-        ebType = c_int(get_entity_type('EX_ELEM_BLOCK'))
-        elem_face_conn = (c_int * len(elemFaceConn))()
+        ebType = ctypes.c_int(get_entity_type('EX_ELEM_BLOCK'))
+        elem_face_conn = (ctypes.c_int * len(elemFaceConn))()
         elem_face_conn[:] = elemFaceConn
-        EXODUS_LIB.ex_put_conn(self.fileId, ebType, c_longlong(blkId),
+        EXODUS_LIB.ex_put_conn(self.fileId, ebType, ctypes.c_longlong(blkId),
                                None, None, elem_face_conn)
         return True
 
@@ -4148,27 +4148,27 @@ class exodus:
                 self.modeChar +
                 " unrecognized.")
 
-        self.comp_ws = c_int(8)
-        self.io_ws = c_int(io_size)
-        self.version = c_float(0.0)
+        self.comp_ws = ctypes.c_int(8)
+        self.io_ws = ctypes.c_int(io_size)
+        self.version = ctypes.c_float(0.0)
         if self.modeChar.lower() in ["a", "r"]:  # open existing file
             self.fileId = EXODUS_LIB.ex_open_int(self.fileName.encode('ascii'), self.mode,
-                                                 byref(self.comp_ws),
-                                                 byref(self.io_ws),
-                                                 byref(self.version),
+                                                 ctypes.byref(self.comp_ws),
+                                                 ctypes.byref(self.io_ws),
+                                                 ctypes.byref(self.version),
                                                  EX_API_VERSION_NODOT)
         else:  # create file
             if io_size == 0:
                 io_size = 8
-                self.io_ws = c_int(io_size)
+                self.io_ws = ctypes.c_int(io_size)
             self.__create()
 
     # --------------------------------------------------------------------
 
     def __create(self):
         self.fileId = EXODUS_LIB.ex_create_int(self.fileName.encode('ascii'), self.mode,
-                                               byref(self.comp_ws),
-                                               byref(self.io_ws),
+                                               ctypes.byref(self.comp_ws),
+                                               ctypes.byref(self.io_ws),
                                                EX_API_VERSION_NODOT)
 
     # --------------------------------------------------------------------
@@ -4183,7 +4183,7 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_info(self):
-        self.Title = create_string_buffer(MAX_LINE_LENGTH + 1)
+        self.Title = ctypes.create_string_buffer(MAX_LINE_LENGTH + 1)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
             self.numDim = ctypes.c_longlong(0)
             self.numNodes = ctypes.c_longlong(0)
@@ -4200,17 +4200,17 @@ class exodus:
             self.numSideSets = ctypes.c_int(0)
         EXODUS_LIB.ex_get_init(
             self.fileId, self.Title,
-            byref(self.numDim),
-            byref(self.numNodes),
-            byref(self.numElem),
-            byref(self.numElemBlk),
-            byref(self.numNodeSets),
-            byref(self.numSideSets))
+            ctypes.byref(self.numDim),
+            ctypes.byref(self.numNodes),
+            ctypes.byref(self.numElem),
+            ctypes.byref(self.numElemBlk),
+            ctypes.byref(self.numNodeSets),
+            ctypes.byref(self.numSideSets))
 
     # --------------------------------------------------------------------
 
     def __ex_put_info(self, info):
-        self.Title = create_string_buffer(info[0].encode('ascii'), MAX_LINE_LENGTH + 1)
+        self.Title = ctypes.create_string_buffer(info[0].encode('ascii'), MAX_LINE_LENGTH + 1)
         self.numDim = ctypes.c_longlong(info[1])
         self.numNodes = ctypes.c_longlong(info[2])
         self.numElem = ctypes.c_longlong(info[3])
@@ -4267,13 +4267,13 @@ class exodus:
 
     def __ex_get_qa(self):
         num_qa_recs = ctypes.c_int(self.__ex_inquire_int(ex_inquiry_map('EX_INQ_QA')))
-        qa_rec_ptrs = ((POINTER(ctypes.c_char * (MAX_STR_LENGTH + 1)) * 4) * num_qa_recs.value)()
+        qa_rec_ptrs = ((ctypes.POINTER(ctypes.c_char * (MAX_STR_LENGTH + 1)) * 4) * num_qa_recs.value)()
         for i in range(num_qa_recs.value):
             for j in range(4):
-                qa_rec_ptrs[i][j] = pointer(
-                    create_string_buffer(MAX_STR_LENGTH + 1))
+                qa_rec_ptrs[i][j] = ctypes.pointer(
+                    ctypes.create_string_buffer(MAX_STR_LENGTH + 1))
         if num_qa_recs.value:
-            EXODUS_LIB.ex_get_qa(self.fileId, byref(qa_rec_ptrs))
+            EXODUS_LIB.ex_get_qa(self.fileId, ctypes.byref(qa_rec_ptrs))
         qa_recs = []
         for qara in qa_rec_ptrs:
             qa_rec_list = []
@@ -4287,24 +4287,24 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_put_qa(self, qaRecs):
-        num_qa_recs = c_int(len(qaRecs))
-        qa_rec_ptrs = ((POINTER(c_char * (MAX_STR_LENGTH + 1)) * 4) * num_qa_recs.value)()
+        num_qa_recs = ctypes.c_int(len(qaRecs))
+        qa_rec_ptrs = ((ctypes.POINTER(ctypes.c_char * (MAX_STR_LENGTH + 1)) * 4) * num_qa_recs.value)()
         for i in range(num_qa_recs.value):
             for j in range(4):
-                qa_rec_ptrs[i][j] = pointer(create_string_buffer(
+                qa_rec_ptrs[i][j] = ctypes.pointer(ctypes.create_string_buffer(
                     str(qaRecs[i][j]).encode('ascii'), MAX_STR_LENGTH + 1))
-        EXODUS_LIB.ex_put_qa(self.fileId, num_qa_recs, byref(qa_rec_ptrs))
+        EXODUS_LIB.ex_put_qa(self.fileId, num_qa_recs, ctypes.byref(qa_rec_ptrs))
         return True
 
     # --------------------------------------------------------------------
 
     def _ex_get_info_recs_quietly(self):
-        num_infos = c_int(self.__ex_inquire_int(ex_inquiry_map('EX_INQ_INFO')))
-        info_ptrs = (POINTER(c_char * (MAX_LINE_LENGTH + 1)) * num_infos.value)()
+        num_infos = ctypes.c_int(self.__ex_inquire_int(ex_inquiry_map('EX_INQ_INFO')))
+        info_ptrs = (ctypes.POINTER(ctypes.c_char * (MAX_LINE_LENGTH + 1)) * num_infos.value)()
         for i in range(num_infos.value):
-            info_ptrs[i] = pointer(create_string_buffer(MAX_LINE_LENGTH + 1))
+            info_ptrs[i] = ctypes.pointer(ctypes.create_string_buffer(MAX_LINE_LENGTH + 1))
         if num_infos.value:
-            EXODUS_LIB.ex_get_info(self.fileId, byref(info_ptrs))
+            EXODUS_LIB.ex_get_info(self.fileId, ctypes.byref(info_ptrs))
         info_recs = []
         for irp in info_ptrs:
             info_recs.append(irp.contents.value.decode("utf8"))
@@ -4313,11 +4313,11 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_info_recs(self):
-        num_infos = c_int(self.__ex_inquire_int(ex_inquiry_map('EX_INQ_INFO')))
-        info_ptrs = (POINTER(c_char * (MAX_LINE_LENGTH + 1)) * num_infos.value)()
+        num_infos = ctypes.c_int(self.__ex_inquire_int(ex_inquiry_map('EX_INQ_INFO')))
+        info_ptrs = (ctypes.POINTER(ctypes.c_char * (MAX_LINE_LENGTH + 1)) * num_infos.value)()
         for i in range(num_infos.value):
-            info_ptrs[i] = pointer(create_string_buffer(MAX_LINE_LENGTH + 1))
-        EXODUS_LIB.ex_get_info(self.fileId, byref(info_ptrs))
+            info_ptrs[i] = ctypes.pointer(ctypes.create_string_buffer(MAX_LINE_LENGTH + 1))
+        EXODUS_LIB.ex_get_info(self.fileId, ctypes.byref(info_ptrs))
         info_recs = []
         for irp in info_ptrs:
             info_recs.append(irp.contents.value.decode("utf8"))
@@ -4331,28 +4331,28 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_put_info_recs(self, infoRecs):
-        num_infos = c_int(len(infoRecs))
-        info_ptrs = (POINTER(c_char * (MAX_LINE_LENGTH + 1)) * num_infos.value)()
+        num_infos = ctypes.c_int(len(infoRecs))
+        info_ptrs = (ctypes.POINTER(ctypes.c_char * (MAX_LINE_LENGTH + 1)) * num_infos.value)()
         for i in range(num_infos.value):
-            info_ptrs[i] = pointer(create_string_buffer(
+            info_ptrs[i] = ctypes.pointer(ctypes.create_string_buffer(
                 str(infoRecs[i]).encode('ascii'), MAX_LINE_LENGTH + 1))
-        EXODUS_LIB.ex_put_info(self.fileId, num_infos, byref(info_ptrs))
+        EXODUS_LIB.ex_put_info(self.fileId, num_infos, ctypes.byref(info_ptrs))
         return True
 
     # --------------------------------------------------------------------
 
     def __ex_inquire_float(self, inq_id):
-        dummy_char = create_string_buffer(MAX_LINE_LENGTH + 1)
-        ret_float = c_float(0.0)
+        dummy_char = ctypes.create_string_buffer(MAX_LINE_LENGTH + 1)
+        ret_float = ctypes.c_float(0.0)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_INQ_INT64_API:
-            dummy_int = c_longlong(0)
+            dummy_int = ctypes.c_longlong(0)
         else:
-            dummy_int = c_int(0)
+            dummy_int = ctypes.c_int(0)
         val = EXODUS_LIB.ex_inquire(
             self.fileId,
             inq_id,
-            byref(dummy_int),
-            byref(ret_float),
+            ctypes.byref(dummy_int),
+            ctypes.byref(ret_float),
             dummy_char)
         if val < 0:
             raise Exception(
@@ -4378,12 +4378,12 @@ class exodus:
 
     def __ex_get_coord_names(self):
         coord_name_ptrs = (
-            POINTER(c_char * (MAX_NAME_LENGTH + 1)) * self.numDim.value)()
+            ctypes.POINTER(ctypes.c_char * (MAX_NAME_LENGTH + 1)) * self.numDim.value)()
         for i in range(self.numDim.value):
-            coord_name_ptrs[i] = pointer(
-                create_string_buffer(
+            coord_name_ptrs[i] = ctypes.pointer(
+                ctypes.create_string_buffer(
                     MAX_NAME_LENGTH + 1))
-        EXODUS_LIB.ex_get_coord_names(self.fileId, byref(coord_name_ptrs))
+        EXODUS_LIB.ex_get_coord_names(self.fileId, ctypes.byref(coord_name_ptrs))
         coord_names = []
         for cnp in coord_name_ptrs:
             coord_names.append(cnp.contents.value.decode('utf8'))
@@ -4393,66 +4393,66 @@ class exodus:
 
     def __ex_put_coord_names(self, names):
         coord_name_ptrs = (
-            POINTER(c_char * (MAX_NAME_LENGTH + 1)) * self.numDim.value)()
+            ctypes.POINTER(ctypes.c_char * (MAX_NAME_LENGTH + 1)) * self.numDim.value)()
         assert len(names) == self.numDim.value
         for i in range(self.numDim.value):
-            coord_name_ptrs[i] = pointer(
-                create_string_buffer(
+            coord_name_ptrs[i] = ctypes.pointer(
+                ctypes.create_string_buffer(
                     names[i].encode('ascii'), MAX_NAME_LENGTH + 1))
-        EXODUS_LIB.ex_put_coord_names(self.fileId, byref(coord_name_ptrs))
+        EXODUS_LIB.ex_put_coord_names(self.fileId, ctypes.byref(coord_name_ptrs))
 
     # --------------------------------------------------------------------
 
     def __ex_get_all_times(self):
-        self.times = (c_double * self.numTimes.value)()
-        EXODUS_LIB.ex_get_all_times(self.fileId, byref(self.times))
+        self.times = (ctypes.c_double * self.numTimes.value)()
+        EXODUS_LIB.ex_get_all_times(self.fileId, ctypes.byref(self.times))
 
     # --------------------------------------------------------------------
 
     def __ex_get_time(self, timeStep):
-        time_step = c_int(timeStep)
-        time_val = c_double(0.0)
-        EXODUS_LIB.ex_get_time(self.fileId, time_step, byref(time_val))
+        time_step = ctypes.c_int(timeStep)
+        time_val = ctypes.c_double(0.0)
+        EXODUS_LIB.ex_get_time(self.fileId, time_step, ctypes.byref(time_val))
         return time_val.value()
 
     # --------------------------------------------------------------------
 
     def __ex_put_time(self, timeStep, timeVal):
-        time_step = c_int(timeStep)
-        time_val = c_double(timeVal)
-        EXODUS_LIB.ex_put_time(self.fileId, time_step, byref(time_val))
+        time_step = ctypes.c_int(timeStep)
+        time_val = ctypes.c_double(timeVal)
+        EXODUS_LIB.ex_put_time(self.fileId, time_step, ctypes.byref(time_val))
         return True
 
     # --------------------------------------------------------------------
 
     def __ex_get_name(self, objType, objId):
-        obj_type = c_int(get_entity_type(objType))
-        obj_id = c_longlong(objId)
-        obj_name = create_string_buffer(MAX_NAME_LENGTH + 1)
-        EXODUS_LIB.ex_get_name(self.fileId, obj_type, obj_id, byref(obj_name))
+        obj_type = ctypes.c_int(get_entity_type(objType))
+        obj_id = ctypes.c_longlong(objId)
+        obj_name = ctypes.create_string_buffer(MAX_NAME_LENGTH + 1)
+        EXODUS_LIB.ex_get_name(self.fileId, obj_type, obj_id, ctypes.byref(obj_name))
         return obj_name.value.decode('utf8')
 
     # --------------------------------------------------------------------
 
     def __ex_put_name(self, objType, objId, objName):
-        obj_type = c_int(get_entity_type(objType))
-        obj_id = c_longlong(objId)
-        obj_name = create_string_buffer(objName.encode('ascii'), MAX_NAME_LENGTH + 1)
+        obj_type = ctypes.c_int(get_entity_type(objType))
+        obj_id = ctypes.c_longlong(objId)
+        obj_name = ctypes.create_string_buffer(objName.encode('ascii'), MAX_NAME_LENGTH + 1)
         EXODUS_LIB.ex_put_name(self.fileId, obj_type, obj_id, obj_name)
 
     # --------------------------------------------------------------------
 
     def __ex_get_names(self, objType):
         inqType = ex_inquiry_map(ex_obj_to_inq(objType))
-        num_objs = c_int(self.__ex_inquire_int(inqType)).value
-        obj_name_ptrs = (POINTER(c_char * (MAX_NAME_LENGTH + 1)) * num_objs)()
+        num_objs = ctypes.c_int(self.__ex_inquire_int(inqType)).value
+        obj_name_ptrs = (ctypes.POINTER(ctypes.c_char * (MAX_NAME_LENGTH + 1)) * num_objs)()
         for i in range(num_objs):
-            obj_name_ptrs[i] = pointer(
-                create_string_buffer(
+            obj_name_ptrs[i] = ctypes.pointer(
+                ctypes.create_string_buffer(
                     MAX_NAME_LENGTH + 1))
 
-        obj_type = c_int(get_entity_type(objType))
-        EXODUS_LIB.ex_get_names(self.fileId, obj_type, byref(obj_name_ptrs))
+        obj_type = ctypes.c_int(get_entity_type(objType))
+        EXODUS_LIB.ex_get_names(self.fileId, obj_type, ctypes.byref(obj_name_ptrs))
         obj_names = []
         for onp in obj_name_ptrs:
             obj_names.append(onp.contents.value.decode('utf8'))
@@ -4462,89 +4462,89 @@ class exodus:
 
     def __ex_put_names(self, objType, objNames):
         inqType = ex_inquiry_map(ex_obj_to_inq(objType))
-        numObjs = c_int(self.__ex_inquire_int(inqType)).value
+        numObjs = ctypes.c_int(self.__ex_inquire_int(inqType)).value
         assert numObjs == len(objNames)
-        obj_name_ptrs = (POINTER(c_char * (MAX_NAME_LENGTH + 1)) * numObjs)()
-        obj_type = c_int(get_entity_type(objType))
+        obj_name_ptrs = (ctypes.POINTER(ctypes.c_char * (MAX_NAME_LENGTH + 1)) * numObjs)()
+        obj_type = ctypes.c_int(get_entity_type(objType))
         for i in range(numObjs):
-            obj_name_ptrs[i] = pointer(
-                create_string_buffer(
+            obj_name_ptrs[i] = ctypes.pointer(
+                ctypes.create_string_buffer(
                     objNames[i].encode('ascii'), MAX_NAME_LENGTH + 1))
-        EXODUS_LIB.ex_put_names(self.fileId, obj_type, byref(obj_name_ptrs))
+        EXODUS_LIB.ex_put_names(self.fileId, obj_type, ctypes.byref(obj_name_ptrs))
 
     # --------------------------------------------------------------------
 
     def __ex_get_ids(self, objType):
         inqType = ex_inquiry_map(ex_obj_to_inq(objType))
-        numObjs = c_int(self.__ex_inquire_int(inqType)).value
+        numObjs = ctypes.c_int(self.__ex_inquire_int(inqType)).value
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_IDS_INT64_API:
-            ids = (c_longlong * numObjs)()
+            ids = (ctypes.c_longlong * numObjs)()
         else:
-            ids = (c_int * numObjs)()
+            ids = (ctypes.c_int * numObjs)()
         if numObjs > 0:
-            obj_type = c_int(get_entity_type(objType))
-            EXODUS_LIB.ex_get_ids(self.fileId, obj_type, byref(ids))
+            obj_type = ctypes.c_int(get_entity_type(objType))
+            EXODUS_LIB.ex_get_ids(self.fileId, obj_type, ctypes.byref(ids))
         return ids
 
     # --------------------------------------------------------------------
 
     def __ex_get_node_set(self, nodeSetId):
-        node_set_id = c_longlong(nodeSetId)
+        node_set_id = ctypes.c_longlong(nodeSetId)
         num_node_set_nodes = self.__ex_get_set_param('EX_NODE_SET', nodeSetId)[0]
         if num_node_set_nodes == 0:
             return []
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
-            set_nodes = (c_longlong * num_node_set_nodes)()
+            set_nodes = (ctypes.c_longlong * num_node_set_nodes)()
         else:
-            set_nodes = (c_int * num_node_set_nodes)()
-        EXODUS_LIB.ex_get_node_set(self.fileId, node_set_id, byref(set_nodes))
+            set_nodes = (ctypes.c_int * num_node_set_nodes)()
+        EXODUS_LIB.ex_get_node_set(self.fileId, node_set_id, ctypes.byref(set_nodes))
         return set_nodes
 
     # --------------------------------------------------------------------
 
     def __ex_put_node_set(self, nodeSetId, nodeSetNodes):
-        node_set_id = c_longlong(nodeSetId)
+        node_set_id = ctypes.c_longlong(nodeSetId)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
-            node_set_nodes = (c_longlong * len(nodeSetNodes))()
+            node_set_nodes = (ctypes.c_longlong * len(nodeSetNodes))()
             for i, node_set_node in enumerate(nodeSetNodes):
-                node_set_nodes[i] = c_longlong(node_set_node)
+                node_set_nodes[i] = ctypes.c_longlong(node_set_node)
         else:
-            node_set_nodes = (c_int * len(nodeSetNodes))()
+            node_set_nodes = (ctypes.c_int * len(nodeSetNodes))()
             for i, node_set_node in enumerate(nodeSetNodes):
-                node_set_nodes[i] = c_int(node_set_node)
+                node_set_nodes[i] = ctypes.c_int(node_set_node)
         EXODUS_LIB.ex_put_node_set(self.fileId, node_set_id, node_set_nodes)
 
     # --------------------------------------------------------------------
 
     def __ex_get_node_set_dist_fact(self, nodeSetId):
-        node_set_id = c_longlong(nodeSetId)
+        node_set_id = ctypes.c_longlong(nodeSetId)
         num_node_set_nodes = self.__ex_get_set_param('EX_NODE_SET', nodeSetId)[0]
-        set_dfs = (c_double * num_node_set_nodes)()
+        set_dfs = (ctypes.c_double * num_node_set_nodes)()
         EXODUS_LIB.ex_get_node_set_dist_fact(
-            self.fileId, node_set_id, byref(set_dfs))
+            self.fileId, node_set_id, ctypes.byref(set_dfs))
         return set_dfs
 
     # --------------------------------------------------------------------
 
     def __ex_put_node_set_dist_fact(self, nodeSetId, nodeSetDistFact):
-        node_set_id = c_longlong(nodeSetId)
-        node_set_dist_fact = (c_double * len(nodeSetDistFact))()
+        node_set_id = ctypes.c_longlong(nodeSetId)
+        node_set_dist_fact = (ctypes.c_double * len(nodeSetDistFact))()
         for i, dist_fact in enumerate(nodeSetDistFact):
-            node_set_dist_fact[i] = c_double(dist_fact)
+            node_set_dist_fact[i] = ctypes.c_double(dist_fact)
         EXODUS_LIB.ex_put_node_set_dist_fact(
             self.fileId, node_set_id, node_set_dist_fact)
 
     # --------------------------------------------------------------------
 
     def __ex_get_object_truth_vector(self, objType, entId):
-        obj_type = c_int(get_entity_type(objType))
-        entity_id = c_longlong(entId)
+        obj_type = ctypes.c_int(get_entity_type(objType))
+        entity_id = ctypes.c_longlong(entId)
         variable_count = self.__ex_get_variable_param(objType)
-        truth_table = (c_int * (variable_count.value))()
+        truth_table = (ctypes.c_int * (variable_count.value))()
 
         EXODUS_LIB.ex_get_object_truth_vector(self.fileId, obj_type,
                                               entity_id, variable_count,
-                                              byref(truth_table))
+                                              ctypes.byref(truth_table))
         truthTab = []
         for val in truth_table:
             if val:
@@ -4557,15 +4557,15 @@ class exodus:
 
     def __ex_get_truth_table(self, objType):
         inqType = ex_inquiry_map(ex_obj_to_inq(objType))
-        num_objs = c_int(self.__ex_inquire_int(inqType)).value
+        num_objs = ctypes.c_int(self.__ex_inquire_int(inqType)).value
 
-        obj_type = c_int(get_entity_type(objType))
+        obj_type = ctypes.c_int(get_entity_type(objType))
         variable_count = self.__ex_get_variable_param(objType)
 
-        truth_table = (c_int * (num_objs * variable_count.value))()
+        truth_table = (ctypes.c_int * (num_objs * variable_count.value))()
         EXODUS_LIB.ex_get_truth_table(self.fileId, obj_type,
                                       num_objs, variable_count,
-                                      byref(truth_table))
+                                      ctypes.byref(truth_table))
         truthTab = []
         for val in truth_table:
             if val:
@@ -4578,19 +4578,19 @@ class exodus:
 
     def __ex_put_truth_table(self, objType, truthTab):
         inqType = ex_inquiry_map(ex_obj_to_inq(objType))
-        num_objs = c_int(self.__ex_inquire_int(inqType)).value
+        num_objs = ctypes.c_int(self.__ex_inquire_int(inqType)).value
 
-        obj_type = c_int(get_entity_type(objType))
+        obj_type = ctypes.c_int(get_entity_type(objType))
         num_vars = self.__ex_get_variable_param(objType).value
 
         assert len(truthTab) == (num_objs * num_vars)
 
-        truth_tab = (c_int * (num_objs * num_vars))()
+        truth_tab = (ctypes.c_int * (num_objs * num_vars))()
         for i, boolVal in enumerate(truthTab):
             if boolVal:
-                truth_tab[i] = c_int(1)
+                truth_tab[i] = ctypes.c_int(1)
             else:
-                truth_tab[i] = c_int(0)
+                truth_tab[i] = ctypes.c_int(0)
 
         EXODUS_LIB.ex_put_truth_table(
             self.fileId, obj_type, num_objs, num_vars, truth_tab)
@@ -4599,61 +4599,61 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_coord(self):
-        self.coordsX = (c_double * self.numNodes.value)()
-        self.coordsY = (c_double * self.numNodes.value)()
-        self.coordsZ = (c_double * self.numNodes.value)()
+        self.coordsX = (ctypes.c_double * self.numNodes.value)()
+        self.coordsY = (ctypes.c_double * self.numNodes.value)()
+        self.coordsZ = (ctypes.c_double * self.numNodes.value)()
         EXODUS_LIB.ex_get_coord(
             self.fileId,
-            byref(self.coordsX),
-            byref(self.coordsY),
-            byref(self.coordsZ))
+            ctypes.byref(self.coordsX),
+            ctypes.byref(self.coordsY),
+            ctypes.byref(self.coordsZ))
 
     # --------------------------------------------------------------------
 
     def __ex_put_coord(self, xCoords, yCoords, zCoords):
-        self.coordsX = (c_double * self.numNodes.value)()
-        self.coordsY = (c_double * self.numNodes.value)()
-        self.coordsZ = (c_double * self.numNodes.value)()
+        self.coordsX = (ctypes.c_double * self.numNodes.value)()
+        self.coordsY = (ctypes.c_double * self.numNodes.value)()
+        self.coordsZ = (ctypes.c_double * self.numNodes.value)()
         for i in range(self.numNodes.value):
             self.coordsX[i] = float(xCoords[i])
             self.coordsY[i] = float(yCoords[i])
             self.coordsZ[i] = float(zCoords[i])
         EXODUS_LIB.ex_put_coord(
             self.fileId,
-            byref(self.coordsX),
-            byref(self.coordsY),
-            byref(self.coordsZ))
+            ctypes.byref(self.coordsX),
+            ctypes.byref(self.coordsY),
+            ctypes.byref(self.coordsZ))
 
     # --------------------------------------------------------------------
 
     def __ex_get_partial_coord(self, startNodeId, numNodes):
-        start_node_num = c_longlong(startNodeId)
-        num_nodes = c_longlong(numNodes)
-        coordsX = (c_double * numNodes)()
-        coordsY = (c_double * numNodes)()
-        coordsZ = (c_double * numNodes)()
+        start_node_num = ctypes.c_longlong(startNodeId)
+        num_nodes = ctypes.c_longlong(numNodes)
+        coordsX = (ctypes.c_double * numNodes)()
+        coordsY = (ctypes.c_double * numNodes)()
+        coordsZ = (ctypes.c_double * numNodes)()
         EXODUS_LIB.ex_get_partial_coord(
             self.fileId,
             start_node_num,
             num_nodes,
-            byref(coordsX),
-            byref(coordsY),
-            byref(coordsZ))
+            ctypes.byref(coordsX),
+            ctypes.byref(coordsY),
+            ctypes.byref(coordsZ))
         return list(coordsX), list(coordsY), list(coordsZ)
 
     # --------------------------------------------------------------------
 
     def __ex_get_id_map(self, objType):
         inqType = ex_obj_to_inq(objType)
-        obj_type = c_int(get_entity_type(objType))
-        inq_type = c_int(ex_inquiry_map(inqType))
-        num_objs = c_int(self.__ex_inquire_int(inq_type))
+        obj_type = ctypes.c_int(get_entity_type(objType))
+        inq_type = ctypes.c_int(ex_inquiry_map(inqType))
+        num_objs = ctypes.c_int(self.__ex_inquire_int(inq_type))
         numObjs = num_objs.value
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_IDS_INT64_API:
-            id_map = (c_longlong * numObjs)()
+            id_map = (ctypes.c_longlong * numObjs)()
         else:
-            id_map = (c_int * numObjs)()
-        EXODUS_LIB.ex_get_id_map(self.fileId, obj_type, byref(id_map))
+            id_map = (ctypes.c_int * numObjs)()
+        EXODUS_LIB.ex_get_id_map(self.fileId, obj_type, ctypes.byref(id_map))
         idMap = []
         for i in range(numObjs):
             idMap.append(id_map[i])
@@ -4665,80 +4665,80 @@ class exodus:
 
     def __ex_put_id_map(self, objType, idMap):
         inqType = ex_obj_to_inq(objType)
-        obj_type = c_int(get_entity_type(objType))
-        inq_type = c_int(ex_inquiry_map(inqType))
-        num_objs = c_int(self.__ex_inquire_int(inq_type))
+        obj_type = ctypes.c_int(get_entity_type(objType))
+        inq_type = ctypes.c_int(ex_inquiry_map(inqType))
+        num_objs = ctypes.c_int(self.__ex_inquire_int(inq_type))
         numObjs = num_objs.value
         assert numObjs == len(idMap)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_IDS_INT64_API:
-            id_map = (c_longlong * numObjs)()
+            id_map = (ctypes.c_longlong * numObjs)()
             for i in range(numObjs):
-                id_map[i] = c_longlong(idMap[i])
+                id_map[i] = ctypes.c_longlong(idMap[i])
         else:
-            id_map = (c_int * numObjs)()
+            id_map = (ctypes.c_int * numObjs)()
             for i in range(numObjs):
-                id_map[i] = c_int(idMap[i])
-        EXODUS_LIB.ex_put_id_map(self.fileId, obj_type, byref(id_map))
+                id_map[i] = ctypes.c_int(idMap[i])
+        EXODUS_LIB.ex_put_id_map(self.fileId, obj_type, ctypes.byref(id_map))
         return True
 
     # --------------------------------------------------------------------
 
     def __ex_get_elem_num_map(self):
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_MAPS_INT64_API:
-            elemNumMap = (c_longlong * self.numElem.value)()
+            elemNumMap = (ctypes.c_longlong * self.numElem.value)()
         else:
-            elemNumMap = (c_int * self.numElem.value)()
-        EXODUS_LIB.ex_get_elem_num_map(self.fileId, byref(elemNumMap))
+            elemNumMap = (ctypes.c_int * self.numElem.value)()
+        EXODUS_LIB.ex_get_elem_num_map(self.fileId, ctypes.byref(elemNumMap))
         return elemNumMap
 
     # --------------------------------------------------------------------
 
     def __ex_get_node_num_map(self):
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_MAPS_INT64_API:
-            nodeNumMap = (c_longlong * self.numNodes.value)()
+            nodeNumMap = (ctypes.c_longlong * self.numNodes.value)()
         else:
-            nodeNumMap = (c_int * self.numNodes.value)()
-        EXODUS_LIB.ex_get_node_num_map(self.fileId, byref(nodeNumMap))
+            nodeNumMap = (ctypes.c_int * self.numNodes.value)()
+        EXODUS_LIB.ex_get_node_num_map(self.fileId, ctypes.byref(nodeNumMap))
         return nodeNumMap
 
     # --------------------------------------------------------------------
 
     def __ex_get_elem_order_map(self):
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_MAPS_INT64_API:
-            elemOrderMap = (c_longlong * self.numElem.value)()
+            elemOrderMap = (ctypes.c_longlong * self.numElem.value)()
         else:
-            elemOrderMap = (c_int * self.numElem.value)()
-        EXODUS_LIB.ex_get_map(self.fileId, byref(elemOrderMap))
+            elemOrderMap = (ctypes.c_int * self.numElem.value)()
+        EXODUS_LIB.ex_get_map(self.fileId, ctypes.byref(elemOrderMap))
         return elemOrderMap
 
     # --------------------------------------------------------------------
 
     def __ex_get_block(self, object_type, object_id):
-        obj_type = c_int(get_entity_type(object_type))
-        block_id = c_longlong(object_id)
-        blk_type = create_string_buffer(MAX_STR_LENGTH + 1)
+        obj_type = ctypes.c_int(get_entity_type(object_type))
+        block_id = ctypes.c_longlong(object_id)
+        blk_type = ctypes.create_string_buffer(MAX_STR_LENGTH + 1)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
-            num_elem_this_blk = c_longlong(0)
-            num_nodes_per_elem = c_longlong(0)
-            num_edges_per_elem = c_longlong(0)
-            num_faces_per_elem = c_longlong(0)
-            num_attr = c_longlong(0)
+            num_elem_this_blk = ctypes.c_longlong(0)
+            num_nodes_per_elem = ctypes.c_longlong(0)
+            num_edges_per_elem = ctypes.c_longlong(0)
+            num_faces_per_elem = ctypes.c_longlong(0)
+            num_attr = ctypes.c_longlong(0)
         else:
-            num_elem_this_blk = c_int(0)
-            num_nodes_per_elem = c_int(0)
-            num_edges_per_elem = c_int(0)
-            num_faces_per_elem = c_int(0)
-            num_attr = c_int(0)
+            num_elem_this_blk = ctypes.c_int(0)
+            num_nodes_per_elem = ctypes.c_int(0)
+            num_edges_per_elem = ctypes.c_int(0)
+            num_faces_per_elem = ctypes.c_int(0)
+            num_attr = ctypes.c_int(0)
         EXODUS_LIB.ex_get_block(
             self.fileId,
             obj_type,
             block_id,
             blk_type,
-            byref(num_elem_this_blk),
-            byref(num_nodes_per_elem),
-            byref(num_edges_per_elem),
-            byref(num_faces_per_elem),
-            byref(num_attr))
+            ctypes.byref(num_elem_this_blk),
+            ctypes.byref(num_nodes_per_elem),
+            ctypes.byref(num_edges_per_elem),
+            ctypes.byref(num_faces_per_elem),
+            ctypes.byref(num_attr))
         return blk_type, num_elem_this_blk, num_nodes_per_elem, num_attr
 
     # --------------------------------------------------------------------
@@ -4751,14 +4751,14 @@ class exodus:
             numElems,
             numNodesPerElem,
             numAttrsPerElem):
-        obj_type = c_int(get_entity_type(object_type))
-        block_id = c_longlong(object_id)
-        elem_type = create_string_buffer(eType.upper(), MAX_NAME_LENGTH + 1)
-        num_elem_this_blk = c_longlong(numElems)
-        num_nodes_per_elem = c_longlong(numNodesPerElem)
-        num_edges_per_elem = c_longlong(0)
-        num_faces_per_elem = c_longlong(0)
-        num_attr = c_longlong(numAttrsPerElem)
+        obj_type = ctypes.c_int(get_entity_type(object_type))
+        block_id = ctypes.c_longlong(object_id)
+        elem_type = ctypes.create_string_buffer(eType.upper(), MAX_NAME_LENGTH + 1)
+        num_elem_this_blk = ctypes.c_longlong(numElems)
+        num_nodes_per_elem = ctypes.c_longlong(numNodesPerElem)
+        num_edges_per_elem = ctypes.c_longlong(0)
+        num_faces_per_elem = ctypes.c_longlong(0)
+        num_attr = ctypes.c_longlong(numAttrsPerElem)
         EXODUS_LIB.ex_put_block(self.fileId, obj_type, block_id, elem_type,
                                 num_elem_this_blk, num_nodes_per_elem,
                                 num_edges_per_elem, num_faces_per_elem, num_attr)
@@ -4768,17 +4768,17 @@ class exodus:
     def __ex_get_elem_conn(self, object_id):
         (_elem_type, num_elem_this_blk, num_nodes_per_elem,
          _num_attr) = self.__ex_get_block('EX_ELEM_BLOCK', object_id)
-        elem_block_id = c_longlong(object_id)
+        elem_block_id = ctypes.c_longlong(object_id)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
             elem_block_connectivity = (
-                c_longlong * (num_elem_this_blk.value * num_nodes_per_elem.value))()
+                ctypes.c_longlong * (num_elem_this_blk.value * num_nodes_per_elem.value))()
         else:
             elem_block_connectivity = (
-                c_int * (num_elem_this_blk.value * num_nodes_per_elem.value))()
+                ctypes.c_int * (num_elem_this_blk.value * num_nodes_per_elem.value))()
         EXODUS_LIB.ex_get_elem_conn(
             self.fileId,
             elem_block_id,
-            byref(elem_block_connectivity))
+            ctypes.byref(elem_block_connectivity))
         return elem_block_connectivity, num_elem_this_blk, num_nodes_per_elem
 
     # --------------------------------------------------------------------
@@ -4786,17 +4786,17 @@ class exodus:
     def __ex_put_elem_conn(self, object_id, connectivity):
         (_elem_type, num_elem_this_blk, num_nodes_per_elem,
          _num_attr) = self.__ex_get_block('EX_ELEM_BLOCK', object_id)
-        elem_block_id = c_longlong(object_id)
+        elem_block_id = ctypes.c_longlong(object_id)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
             elem_block_connectivity = (
-                c_longlong * (num_elem_this_blk.value * num_nodes_per_elem.value))()
+                ctypes.c_longlong * (num_elem_this_blk.value * num_nodes_per_elem.value))()
             for i in range(num_elem_this_blk.value * num_nodes_per_elem.value):
-                elem_block_connectivity[i] = c_longlong(connectivity[i])
+                elem_block_connectivity[i] = ctypes.c_longlong(connectivity[i])
         else:
             elem_block_connectivity = (
-                c_int * (num_elem_this_blk.value * num_nodes_per_elem.value))()
+                ctypes.c_int * (num_elem_this_blk.value * num_nodes_per_elem.value))()
             for i in range(num_elem_this_blk.value * num_nodes_per_elem.value):
-                elem_block_connectivity[i] = c_int(connectivity[i])
+                elem_block_connectivity[i] = ctypes.c_int(connectivity[i])
         EXODUS_LIB.ex_put_elem_conn(
             self.fileId,
             elem_block_id,
@@ -4805,10 +4805,10 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_put_one_attr(self, objType, elemBlkID, attrIndx, Attr):
-        elem_blk_id = c_longlong(elemBlkID)
-        obj_type = c_int(objType)
-        attr_index = c_longlong(attrIndx)
-        attrib = (c_double * len(Attr))()
+        elem_blk_id = ctypes.c_longlong(elemBlkID)
+        obj_type = ctypes.c_int(objType)
+        attr_index = ctypes.c_longlong(attrIndx)
+        attrib = (ctypes.c_double * len(Attr))()
         for i, attr in enumerate(Attr):
             attrib[i] = float(attr)
         EXODUS_LIB.ex_put_one_attr(
@@ -4821,55 +4821,55 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_one_attr(self, objType, elemBlkID, attrIndx):
-        elem_blk_id = c_longlong(elemBlkID)
-        obj_type = c_int(objType)
-        attr_index = c_longlong(attrIndx)
+        elem_blk_id = ctypes.c_longlong(elemBlkID)
+        obj_type = ctypes.c_int(objType)
+        attr_index = ctypes.c_longlong(attrIndx)
         inqType = ex_inquiry_map(ex_obj_to_inq(objType))
-        num_objs = c_int(self.__ex_inquire_int(inqType)).value
-        attrib = (c_double * num_objs)()
+        num_objs = ctypes.c_int(self.__ex_inquire_int(inqType)).value
+        attrib = (ctypes.c_double * num_objs)()
         EXODUS_LIB.ex_get_one_attr(
             self.fileId,
             obj_type,
             elem_blk_id,
             attr_index,
-            byref(attrib))
+            ctypes.byref(attrib))
         return attrib
 
     # --------------------------------------------------------------------
 
     def __ex_put_elem_attr(self, elemBlkID, Attr):
-        elem_blk_id = c_longlong(elemBlkID)
-        attrib = (c_double * len(Attr))()
+        elem_blk_id = ctypes.c_longlong(elemBlkID)
+        attrib = (ctypes.c_double * len(Attr))()
         for i, attr in enumerate(Attr):
-            attrib[i] = c_double(attr)
+            attrib[i] = ctypes.c_double(attr)
         EXODUS_LIB.ex_put_attr(
             self.fileId,
-            c_int(get_entity_type('EX_ELEM_BLOCK')),
+            ctypes.c_int(get_entity_type('EX_ELEM_BLOCK')),
             elem_blk_id,
             attrib)
 
     # --------------------------------------------------------------------
 
     def __ex_get_elem_attr(self, elemBlkID):
-        elem_blk_id = c_longlong(elemBlkID)
+        elem_blk_id = ctypes.c_longlong(elemBlkID)
         numAttrThisBlk = self.num_attr(elemBlkID)
         numElemsThisBlk = self.num_elems_in_blk(elemBlkID)
         totalAttr = numAttrThisBlk * numElemsThisBlk
-        attrib = (c_double * totalAttr)()
+        attrib = (ctypes.c_double * totalAttr)()
         EXODUS_LIB.ex_get_attr(
             self.fileId,
-            c_int(get_entity_type('EX_ELEM_BLOCK')),
+            ctypes.c_int(get_entity_type('EX_ELEM_BLOCK')),
             elem_blk_id,
-            byref(attrib))
+            ctypes.byref(attrib))
         return attrib
 
     # --------------------------------------------------------------------
 
     def __ex_get_variable_param(self, varType):
-        var_type = c_int(get_entity_type(varType))
-        num_vars = c_int()
+        var_type = ctypes.c_int(get_entity_type(varType))
+        num_vars = ctypes.c_int()
         EXODUS_LIB.ex_get_variable_param(
-            self.fileId, var_type, byref(num_vars))
+            self.fileId, var_type, ctypes.byref(num_vars))
         return num_vars
 
     # --------------------------------------------------------------------
@@ -4877,19 +4877,19 @@ class exodus:
     def __ex_get_variable_names(self, varType):
         num_vars = self.__ex_get_variable_param(varType)
         var_name_ptrs = (
-            POINTER(c_char * (MAX_NAME_LENGTH + 1)) * num_vars.value)()
+            ctypes.POINTER(ctypes.c_char * (MAX_NAME_LENGTH + 1)) * num_vars.value)()
 
         for i in range(num_vars.value):
-            var_name_ptrs[i] = pointer(
-                create_string_buffer(
+            var_name_ptrs[i] = ctypes.pointer(
+                ctypes.create_string_buffer(
                     MAX_NAME_LENGTH + 1))
 
-        var_type = c_int(get_entity_type(varType))
+        var_type = ctypes.c_int(get_entity_type(varType))
         EXODUS_LIB.ex_get_variable_names(
             self.fileId,
             var_type,
             num_vars,
-            byref(var_name_ptrs))
+            ctypes.byref(var_name_ptrs))
         var_names = []
         for vnp in var_name_ptrs:
             var_names.append(vnp.contents.value.decode('utf8'))
@@ -4898,12 +4898,12 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_var(self, timeStep, varType, varId, blkId, numValues):
-        step = c_int(timeStep)
-        var_type = c_int(get_entity_type(varType))
-        var_id = c_int(varId)
-        block_id = c_longlong(blkId)
-        num_values = c_longlong(numValues)
-        var_vals = (c_double * num_values.value)()
+        step = ctypes.c_int(timeStep)
+        var_type = ctypes.c_int(get_entity_type(varType))
+        var_id = ctypes.c_int(varId)
+        block_id = ctypes.c_longlong(blkId)
+        num_values = ctypes.c_longlong(numValues)
+        var_vals = (ctypes.c_double * num_values.value)()
         EXODUS_LIB.ex_get_var(
             self.fileId,
             step,
@@ -4917,12 +4917,12 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_put_var(self, timeStep, varType, varId, blkId, numValues, values):
-        step = c_int(timeStep)
-        var_type = c_int(get_entity_type(varType))
-        var_id = c_int(varId)
-        block_id = c_longlong(blkId)
-        num_values = c_longlong(numValues)
-        var_vals = (c_double * num_values.value)()
+        step = ctypes.c_int(timeStep)
+        var_type = ctypes.c_int(get_entity_type(varType))
+        var_id = ctypes.c_int(varId)
+        block_id = ctypes.c_longlong(blkId)
+        num_values = ctypes.c_longlong(numValues)
+        var_vals = (ctypes.c_double * num_values.value)()
         for i in range(num_values.value):
             var_vals[i] = float(values[i])
         EXODUS_LIB.ex_put_var(
@@ -4938,41 +4938,41 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_side_set_node_list_len(self, object_id):
-        side_set_id = c_longlong(object_id)
+        side_set_id = ctypes.c_longlong(object_id)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
-            side_set_node_list_len = c_longlong(0)
+            side_set_node_list_len = ctypes.c_longlong(0)
         else:
-            side_set_node_list_len = c_int(0)
+            side_set_node_list_len = ctypes.c_int(0)
         EXODUS_LIB.ex_get_side_set_node_list_len(
-            self.fileId, side_set_id, byref(side_set_node_list_len))
+            self.fileId, side_set_id, ctypes.byref(side_set_node_list_len))
         return side_set_node_list_len
 
     # --------------------------------------------------------------------
 
     def __ex_get_set_param(self, objType, object_id):
-        object_type = c_int(get_entity_type(objType))
-        side_set_id = c_longlong(object_id)
+        object_type = ctypes.c_int(get_entity_type(objType))
+        side_set_id = ctypes.c_longlong(object_id)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
-            num_side_in_set = c_longlong(0)
-            num_dist_fact_in_set = c_longlong(0)
+            num_side_in_set = ctypes.c_longlong(0)
+            num_dist_fact_in_set = ctypes.c_longlong(0)
         else:
-            num_side_in_set = c_int(0)
-            num_dist_fact_in_set = c_int(0)
+            num_side_in_set = ctypes.c_int(0)
+            num_dist_fact_in_set = ctypes.c_int(0)
         EXODUS_LIB.ex_get_set_param(
             self.fileId,
             object_type,
             side_set_id,
-            byref(num_side_in_set),
-            byref(num_dist_fact_in_set))
+            ctypes.byref(num_side_in_set),
+            ctypes.byref(num_dist_fact_in_set))
         return int(num_side_in_set.value), int(num_dist_fact_in_set.value)
 
     # --------------------------------------------------------------------
 
     def __ex_put_set_param(self, objType, object_id, numSides, numDistFacts):
-        object_type = c_int(get_entity_type(objType))
-        side_set_id = c_longlong(object_id)
-        num_side_in_set = c_longlong(numSides)
-        num_dist_fact_in_set = c_longlong(numDistFacts)
+        object_type = ctypes.c_int(get_entity_type(objType))
+        side_set_id = ctypes.c_longlong(object_id)
+        num_side_in_set = ctypes.c_longlong(numSides)
+        num_dist_fact_in_set = ctypes.c_longlong(numDistFacts)
         EXODUS_LIB.ex_put_set_param(
             self.fileId,
             object_type,
@@ -4984,37 +4984,37 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_side_set(self, sideSetId):
-        side_set_id = c_longlong(sideSetId)
+        side_set_id = ctypes.c_longlong(sideSetId)
         (num_side_in_set, _num_dist_fact_in_set) = self.__ex_get_set_param('EX_SIDE_SET', sideSetId)
         if num_side_in_set == 0:
             return [], []
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
-            side_set_elem_list = (c_longlong * num_side_in_set)()
-            side_set_side_list = (c_longlong * num_side_in_set)()
+            side_set_elem_list = (ctypes.c_longlong * num_side_in_set)()
+            side_set_side_list = (ctypes.c_longlong * num_side_in_set)()
         else:
-            side_set_elem_list = (c_int * num_side_in_set)()
-            side_set_side_list = (c_int * num_side_in_set)()
+            side_set_elem_list = (ctypes.c_int * num_side_in_set)()
+            side_set_side_list = (ctypes.c_int * num_side_in_set)()
         EXODUS_LIB.ex_get_side_set(self.fileId, side_set_id,
-                                   byref(side_set_elem_list),
-                                   byref(side_set_side_list))
+                                   ctypes.byref(side_set_elem_list),
+                                   ctypes.byref(side_set_side_list))
         return side_set_elem_list, side_set_side_list
 
     # --------------------------------------------------------------------
 
     def __ex_put_side_set(self, object_id, sideSetElements, sideSetSides):
-        side_set_id = c_longlong(object_id)
+        side_set_id = ctypes.c_longlong(object_id)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
-            side_set_elem_list = (c_longlong * len(sideSetElements))()
-            side_set_side_list = (c_longlong * len(sideSetSides))()
+            side_set_elem_list = (ctypes.c_longlong * len(sideSetElements))()
+            side_set_side_list = (ctypes.c_longlong * len(sideSetSides))()
             for i, sse in enumerate(sideSetElements):
-                side_set_elem_list[i] = c_longlong(sse)
-                side_set_side_list[i] = c_longlong(sideSetSides[i])
+                side_set_elem_list[i] = ctypes.c_longlong(sse)
+                side_set_side_list[i] = ctypes.c_longlong(sideSetSides[i])
         else:
-            side_set_elem_list = (c_int * len(sideSetElements))()
-            side_set_side_list = (c_int * len(sideSetSides))()
+            side_set_elem_list = (ctypes.c_int * len(sideSetElements))()
+            side_set_side_list = (ctypes.c_int * len(sideSetSides))()
             for i, sse in enumerate(sideSetElements):
-                side_set_elem_list[i] = c_int(sse)
-                side_set_side_list[i] = c_int(sideSetSides[i])
+                side_set_elem_list[i] = ctypes.c_int(sse)
+                side_set_side_list[i] = ctypes.c_int(sideSetSides[i])
         EXODUS_LIB.ex_put_side_set(
             self.fileId,
             side_set_id,
@@ -5025,51 +5025,51 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_side_set_dist_fact(self, sideSetId):
-        side_set_id = c_longlong(sideSetId)
+        side_set_id = ctypes.c_longlong(sideSetId)
         side_set_node_list_len = self.__ex_get_side_set_node_list_len(
             sideSetId)
-        set_dfs = (c_double * side_set_node_list_len.value)()
+        set_dfs = (ctypes.c_double * side_set_node_list_len.value)()
         EXODUS_LIB.ex_get_side_set_dist_fact(
-            self.fileId, side_set_id, byref(set_dfs))
+            self.fileId, side_set_id, ctypes.byref(set_dfs))
         return set_dfs
 
     # --------------------------------------------------------------------
 
     def __ex_put_side_set_dist_fact(self, sideSetId, sideSetDistFact):
-        side_set_id = c_longlong(sideSetId)
-        side_set_dist_fact = (c_double * len(sideSetDistFact))()
+        side_set_id = ctypes.c_longlong(sideSetId)
+        side_set_dist_fact = (ctypes.c_double * len(sideSetDistFact))()
         for i, df in enumerate(sideSetDistFact):
-            side_set_dist_fact[i] = c_double(df)
+            side_set_dist_fact[i] = ctypes.c_double(df)
         EXODUS_LIB.ex_put_side_set_dist_fact(
             self.fileId, side_set_id, side_set_dist_fact)
 
     # --------------------------------------------------------------------
 
     def __ex_get_side_set_node_list(self, object_id):
-        side_set_id = c_longlong(object_id)
+        side_set_id = ctypes.c_longlong(object_id)
         side_set_node_list_len = self.__ex_get_side_set_node_list_len(object_id)
         (num_side_in_set, _num_dist_fact_in_set) = self.__ex_get_set_param('EX_SIDE_SET', object_id)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
-            side_set_node_cnt_list = (c_longlong * num_side_in_set)()
-            side_set_node_list = (c_longlong * side_set_node_list_len.value)()
+            side_set_node_cnt_list = (ctypes.c_longlong * num_side_in_set)()
+            side_set_node_list = (ctypes.c_longlong * side_set_node_list_len.value)()
         else:
-            side_set_node_cnt_list = (c_int * num_side_in_set)()
-            side_set_node_list = (c_int * side_set_node_list_len.value)()
+            side_set_node_cnt_list = (ctypes.c_int * num_side_in_set)()
+            side_set_node_list = (ctypes.c_int * side_set_node_list_len.value)()
         EXODUS_LIB.ex_get_side_set_node_list(self.fileId, side_set_id,
-                                             byref(side_set_node_cnt_list),
-                                             byref(side_set_node_list))
+                                             ctypes.byref(side_set_node_cnt_list),
+                                             ctypes.byref(side_set_node_list))
         return side_set_node_cnt_list, side_set_node_list
 
     # --------------------------------------------------------------------
 
     def __ex_put_variable_param(self, varType, numVars):
-        num_vars = c_int(numVars)
+        num_vars = ctypes.c_int(numVars)
         current_num = self.__ex_get_variable_param(varType)
         if current_num.value == num_vars.value:
             # print "value already set"
             return True
 
-        var_type = c_int(get_entity_type(varType))
+        var_type = ctypes.c_int(get_entity_type(varType))
         errorInt = EXODUS_LIB.ex_put_variable_param(
             self.fileId, var_type, num_vars)
         if errorInt != 0:
@@ -5082,32 +5082,32 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_variable_name(self, varType, varId):
-        var_type = c_int(varType)
-        var_id = c_int(varId)
-        name = create_string_buffer(MAX_NAME_LENGTH + 1)
+        var_type = ctypes.c_int(varType)
+        var_id = ctypes.c_int(varId)
+        name = ctypes.create_string_buffer(MAX_NAME_LENGTH + 1)
         EXODUS_LIB.ex_get_variable_name(self.fileId, var_type, var_id, name)
         return name.decode('utf8')
 
     # --------------------------------------------------------------------
 
     def __ex_put_variable_name(self, varType, varId, varName):
-        var_type = c_int(get_entity_type(varType))
-        var_id = c_int(varId)
-        name = create_string_buffer(varName.encode('ascii'), MAX_NAME_LENGTH + 1)
+        var_type = ctypes.c_int(get_entity_type(varType))
+        var_id = ctypes.c_int(varId)
+        name = ctypes.create_string_buffer(varName.encode('ascii'), MAX_NAME_LENGTH + 1)
         EXODUS_LIB.ex_put_variable_name(self.fileId, var_type, var_id, name)
         return True
 
     # --------------------------------------------------------------------
 
     def __ex_get_elem_attr_names(self, blkId):
-        object_id = c_longlong(blkId)
-        num_attr = c_int(self.num_attr(blkId))
+        object_id = ctypes.c_longlong(blkId)
+        num_attr = ctypes.c_int(self.num_attr(blkId))
         len_name = self.__ex_inquire_int(ex_inquiry_map('EX_INQ_MAX_READ_NAME_LENGTH'))
-        attr_name_ptrs = (POINTER(c_char * (len_name + 1)) * num_attr.value)()
+        attr_name_ptrs = (ctypes.POINTER(ctypes.c_char * (len_name + 1)) * num_attr.value)()
         for i in range(num_attr.value):
-            attr_name_ptrs[i] = pointer(create_string_buffer(len_name + 1))
+            attr_name_ptrs[i] = ctypes.pointer(ctypes.create_string_buffer(len_name + 1))
         EXODUS_LIB.ex_get_elem_attr_names(
-            self.fileId, object_id, byref(attr_name_ptrs))
+            self.fileId, object_id, ctypes.byref(attr_name_ptrs))
         attr_names = []
         for cnp in attr_name_ptrs:
             attr_names.append(cnp.contents.value.decode('utf8'))
@@ -5116,32 +5116,32 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_put_elem_attr_names(self, blkId, varNames):
-        object_id = c_int(blkId)
-        num_attr = c_int(self.num_attr(blkId))
+        object_id = ctypes.c_int(blkId)
+        num_attr = ctypes.c_int(self.num_attr(blkId))
         len_name = self.__ex_inquire_int(ex_inquiry_map('EX_INQ_MAX_READ_NAME_LENGTH'))
-        attr_name_ptrs = (POINTER(c_char * (len_name + 1)) * num_attr.value)()
+        attr_name_ptrs = (ctypes.POINTER(ctypes.c_char * (len_name + 1)) * num_attr.value)()
         assert len(varNames) == num_attr.value
         for i in range(num_attr.value):
-            attr_name_ptrs[i] = pointer(
-                create_string_buffer(
+            attr_name_ptrs[i] = ctypes.pointer(
+                ctypes.create_string_buffer(
                     varNames[i].encode('ascii'), len_name + 1))
         EXODUS_LIB.ex_put_elem_attr_names(
-            self.fileId, object_id, byref(attr_name_ptrs))
+            self.fileId, object_id, ctypes.byref(attr_name_ptrs))
         return True
 
     # --------------------------------------------------------------------
 
     def __ex_get_prop_names(self, varType, inqType):
-        var_type = c_int(get_entity_type(varType))
-        num_props = c_int(self.__ex_inquire_int(ex_inquiry_map(inqType)))
+        var_type = ctypes.c_int(get_entity_type(varType))
+        num_props = ctypes.c_int(self.__ex_inquire_int(ex_inquiry_map(inqType)))
         prop_name_ptrs = (
-            POINTER(c_char * (MAX_STR_LENGTH + 1)) * num_props.value)()
+            ctypes.POINTER(ctypes.c_char * (MAX_STR_LENGTH + 1)) * num_props.value)()
         for i in range(num_props.value):
-            prop_name_ptrs[i] = pointer(
-                create_string_buffer(
+            prop_name_ptrs[i] = ctypes.pointer(
+                ctypes.create_string_buffer(
                     MAX_STR_LENGTH + 1))
         EXODUS_LIB.ex_get_prop_names(
-            self.fileId, var_type, byref(prop_name_ptrs))
+            self.fileId, var_type, ctypes.byref(prop_name_ptrs))
         prop_names = []
         for cnp in prop_name_ptrs:
             prop_names.append(cnp.contents.value.decode('utf8'))
@@ -5150,33 +5150,33 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_prop(self, objType, objId, propName):
-        obj_type = c_int(get_entity_type(objType))
-        obj_id = c_longlong(objId)
-        prop_name = create_string_buffer(propName.encode('ascii'), MAX_STR_LENGTH + 1)
+        obj_type = ctypes.c_int(get_entity_type(objType))
+        obj_id = ctypes.c_longlong(objId)
+        prop_name = ctypes.create_string_buffer(propName.encode('ascii'), MAX_STR_LENGTH + 1)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_IDS_INT64_API:
-            prop_val = c_longlong(0)
+            prop_val = ctypes.c_longlong(0)
         else:
-            prop_val = c_int(0)
+            prop_val = ctypes.c_int(0)
         EXODUS_LIB.ex_get_prop(
             self.fileId,
             obj_type,
             obj_id,
-            byref(prop_name),
-            byref(prop_val))
+            ctypes.byref(prop_name),
+            ctypes.byref(prop_val))
         return prop_val.value
 
     # --------------------------------------------------------------------
 
     def __ex_put_prop(self, objType, objId, propName, propVal):
-        obj_type = c_int(get_entity_type(objType))
-        obj_id = c_longlong(objId)
-        prop_name = create_string_buffer(propName.encode('ascii'), MAX_STR_LENGTH + 1)
-        prop_val = c_longlong(propVal)
+        obj_type = ctypes.c_int(get_entity_type(objType))
+        obj_id = ctypes.c_longlong(objId)
+        prop_name = ctypes.create_string_buffer(propName.encode('ascii'), MAX_STR_LENGTH + 1)
+        prop_val = ctypes.c_longlong(propVal)
         EXODUS_LIB.ex_put_prop(
             self.fileId,
             obj_type,
             obj_id,
-            byref(prop_name),
+            ctypes.byref(prop_name),
             prop_val)
         return True
 

--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -88,7 +88,7 @@ import sys
 if sys.version_info[0] < 3:
     raise Exception("Python-3 version. If using python-2, try `import exodus2 as exodus`")
 
-from ctypes import *
+import ctypes
 import os
 import locale
 from enum import Enum

--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -95,10 +95,10 @@ from enum import Enum
 
 EXODUS_PY_COPYRIGHT_AND_LICENSE = __doc__
 
-EXODUS_PY_VERSION = "1.16 (seacas-py3)"
+EXODUS_PY_VERSION = "1.17 (seacas-py3)"
 
 EXODUS_PY_COPYRIGHT = """
-You are using exodus.py v 1.16 (seacas-py3), a python wrapper of some of the exodus library.
+You are using exodus.py v 1.17 (seacas-py3), a python wrapper of some of the exodus library.
 
 Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019 National Technology &
 Engineering Solutions of Sandia, LLC (NTESS).  Under the terms of
@@ -189,7 +189,7 @@ if os.uname()[0] == 'Darwin':
     EXODUS_SO = ACCESS + "/lib/libexodus.dylib"
 else:
     EXODUS_SO = ACCESS + "/lib/libexodus.so"
-EXODUS_LIB = cdll.LoadLibrary(EXODUS_SO)
+EXODUS_LIB = ctypes.cdll.LoadLibrary(EXODUS_SO)
 
 MAX_STR_LENGTH = 32      # match exodus default
 MAX_NAME_LENGTH = 256     # match exodus default
@@ -243,7 +243,7 @@ EX_MPIPOSIX = 0x40000  # \deprecated As of libhdf5 1.8.13.
 EX_PNETCDF = 0x80000
 
 # set exodus error output option
-exErrPrintMode = c_int(ex_options.EX_VERBOSE.value)
+exErrPrintMode = ctypes.c_int(ex_options.EX_VERBOSE.value)
 EXODUS_LIB.ex_opts(exErrPrintMode)
 
 
@@ -420,7 +420,7 @@ def get_entity_type(varType):
 
 
 # init params struct
-class ex_init_params(Structure):
+class ex_init_params(ctypes.Structure):
     """
     Parameters defining the model dimension, note that many are optional.
 
@@ -587,10 +587,10 @@ class exodus:
                 assert None not in info
                 self.__ex_put_info(info)
 
-            self.numTimes = c_int(0)
+            self.numTimes = ctypes.c_int(0)
         else:
             self.__ex_get_info()
-            self.numTimes = c_int(
+            self.numTimes = ctypes.c_int(
                 self.__ex_inquire_int(
                     ex_inquiry_map('EX_INQ_TIME')))
 
@@ -680,12 +680,12 @@ class exodus:
             p.title = p.title[-1*MAX_LINE_LENGTH:]
 
         self.Title = create_string_buffer(p.title, MAX_LINE_LENGTH + 1)
-        self.numDim = c_longlong(p.num_dim)
-        self.numNodes = c_longlong(p.num_nodes)
-        self.numElem = c_longlong(p.num_elem)
-        self.numElemBlk = c_longlong(p.num_elem_blk)
-        self.numNodeSets = c_longlong(p.num_node_sets)
-        self.numSideSets = c_longlong(p.num_side_sets)
+        self.numDim = ctypes.c_longlong(p.num_dim)
+        self.numNodes = ctypes.c_longlong(p.num_nodes)
+        self.numElem = ctypes.c_longlong(p.num_elem)
+        self.numElemBlk = ctypes.c_longlong(p.num_elem_blk)
+        self.numNodeSets = ctypes.c_longlong(p.num_node_sets)
+        self.numSideSets = ctypes.c_longlong(p.num_side_sets)
 
         EXODUS_LIB.ex_put_init_ext(self.fileId, byref(p))
         return True
@@ -1005,7 +1005,7 @@ class exodus:
             True = successful execution
         """
         self.__ex_put_time(step, value)
-        self.numTimes = c_int(self.__ex_inquire_int(ex_inquiry_map('EX_INQ_TIME')))
+        self.numTimes = ctypes.c_int(self.__ex_inquire_int(ex_inquiry_map('EX_INQ_TIME')))
         return True
 
     #
@@ -1256,7 +1256,7 @@ class exodus:
 
         Returns
         -------
-            <list<c_int>>  node_id_map
+            <list<ctypes.c_int>>  node_id_map
         """
         nodeNumMap = self.__ex_get_node_num_map()
         return nodeNumMap
@@ -3841,8 +3841,8 @@ class exodus:
         values[names.index(name)] = c_double(value)
         # write them all
         EXODUS_LIB.ex_put_var(self.fileId,
-                              c_int(step),
-                              c_int(numVals),
+                              ctypes.c_int(step),
+                              ctypes.c_int(numVals),
                               values)
         return True
 
@@ -3871,8 +3871,8 @@ class exodus:
         for i in range(numVals):
             gvalues[i] = c_double(values[i])
         EXODUS_LIB.ex_put_glob_vars(self.fileId,
-                                    c_int(step),
-                                    c_int(numVals),
+                                    ctypes.c_int(step),
+                                    ctypes.c_int(numVals),
                                     gvalues)
         return True
 
@@ -3934,14 +3934,14 @@ class exodus:
             True = successful execution
         """
 
-        ebType = c_int(get_entity_type('EX_ELEM_BLOCK'))
-        EXODUS_LIB.ex_put_block(self.fileId, ebType, c_longlong(blkID),
+        ebType = ctypes.c_int(get_entity_type('EX_ELEM_BLOCK'))
+        EXODUS_LIB.ex_put_block(self.fileId, ebType, ctypes.c_longlong(blkID),
                                 create_string_buffer(b"NFACED"),
-                                c_longlong(num_elems_this_blk),
-                                c_longlong(0),
-                                c_longlong(0),
-                                c_longlong(num_faces),
-                                c_longlong(num_attr_per_elem))
+                                ctypes.c_longlong(num_elems_this_blk),
+                                ctypes.c_longlong(0),
+                                ctypes.c_longlong(0),
+                                ctypes.c_longlong(num_faces),
+                                ctypes.c_longlong(num_attr_per_elem))
         return True
 
     # --------------------------------------------------------------------
@@ -4001,11 +4001,11 @@ class exodus:
         status : bool
             True = successful execution
         """
-        ebType = c_int(get_entity_type('EX_ELEM_BLOCK'))
-        entity_counts = (c_int * len(entityCounts))()
+        ebType = ctypes.c_int(get_entity_type('EX_ELEM_BLOCK'))
+        entity_counts = (ctypes.c_int * len(entityCounts))()
         entity_counts[:] = entityCounts
         EXODUS_LIB.ex_put_entity_count_per_polyhedra(
-            self.fileId, ebType, c_longlong(blkID), entity_counts)
+            self.fileId, ebType, ctypes.c_longlong(blkID), entity_counts)
         return True
 
     # --------------------------------------------------------------------
@@ -4091,10 +4091,10 @@ class exodus:
         status : bool
             True = successful execution
         """
-        ebType = c_int(get_entity_type('EX_FACE_BLOCK'))
-        node_conn = (c_int * len(faceNodeConn))()
+        ebType = ctypes.c_int(get_entity_type('EX_FACE_BLOCK'))
+        node_conn = (ctypes.c_int * len(faceNodeConn))()
         node_conn[:] = faceNodeConn
-        EXODUS_LIB.ex_put_conn(self.fileId, ebType, c_longlong(blkId),
+        EXODUS_LIB.ex_put_conn(self.fileId, ebType, ctypes.c_longlong(blkId),
                                node_conn, None, None)
         return True
 
@@ -4185,19 +4185,19 @@ class exodus:
     def __ex_get_info(self):
         self.Title = create_string_buffer(MAX_LINE_LENGTH + 1)
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_BULK_INT64_API:
-            self.numDim = c_longlong(0)
-            self.numNodes = c_longlong(0)
-            self.numElem = c_longlong(0)
-            self.numElemBlk = c_longlong(0)
-            self.numNodeSets = c_longlong(0)
-            self.numSideSets = c_longlong(0)
+            self.numDim = ctypes.c_longlong(0)
+            self.numNodes = ctypes.c_longlong(0)
+            self.numElem = ctypes.c_longlong(0)
+            self.numElemBlk = ctypes.c_longlong(0)
+            self.numNodeSets = ctypes.c_longlong(0)
+            self.numSideSets = ctypes.c_longlong(0)
         else:
-            self.numDim = c_int(0)
-            self.numNodes = c_int(0)
-            self.numElem = c_int(0)
-            self.numElemBlk = c_int(0)
-            self.numNodeSets = c_int(0)
-            self.numSideSets = c_int(0)
+            self.numDim = ctypes.c_int(0)
+            self.numNodes = ctypes.c_int(0)
+            self.numElem = ctypes.c_int(0)
+            self.numElemBlk = ctypes.c_int(0)
+            self.numNodeSets = ctypes.c_int(0)
+            self.numSideSets = ctypes.c_int(0)
         EXODUS_LIB.ex_get_init(
             self.fileId, self.Title,
             byref(self.numDim),
@@ -4211,12 +4211,12 @@ class exodus:
 
     def __ex_put_info(self, info):
         self.Title = create_string_buffer(info[0].encode('ascii'), MAX_LINE_LENGTH + 1)
-        self.numDim = c_longlong(info[1])
-        self.numNodes = c_longlong(info[2])
-        self.numElem = c_longlong(info[3])
-        self.numElemBlk = c_longlong(info[4])
-        self.numNodeSets = c_longlong(info[5])
-        self.numSideSets = c_longlong(info[6])
+        self.numDim = ctypes.c_longlong(info[1])
+        self.numNodes = ctypes.c_longlong(info[2])
+        self.numElem = ctypes.c_longlong(info[3])
+        self.numElemBlk = ctypes.c_longlong(info[4])
+        self.numNodeSets = ctypes.c_longlong(info[5])
+        self.numSideSets = ctypes.c_longlong(info[6])
         EXODUS_LIB.ex_put_init(
             self.fileId,
             self.Title,
@@ -4233,27 +4233,27 @@ class exodus:
     def __ex_put_concat_elem_blk(self, elemBlkIDs, elemType, numElemThisBlk,
                                  numNodesPerElem, numAttr, defineMaps):
         if EXODUS_LIB.ex_int64_status(self.fileId) & EX_IDS_INT64_API:
-            elem_blk_ids = (c_longlong * len(elemBlkIDs))()
+            elem_blk_ids = (ctypes.c_longlong * len(elemBlkIDs))()
             elem_blk_ids[:] = elemBlkIDs
-            num_elem_this_blk = (c_longlong
+            num_elem_this_blk = (ctypes.c_longlong
                                  * len(elemBlkIDs))()
             num_elem_this_blk[:] = numElemThisBlk
-            num_nodes_per_elem = (c_longlong * len(elemBlkIDs))()
+            num_nodes_per_elem = (ctypes.c_longlong * len(elemBlkIDs))()
             num_nodes_per_elem[:] = numNodesPerElem
-            num_attr = (c_longlong * len(elemBlkIDs))()
+            num_attr = (ctypes.c_longlong * len(elemBlkIDs))()
             num_attr[:] = numAttr
         else:
-            elem_blk_ids = (c_int * len(elemBlkIDs))()
+            elem_blk_ids = (ctypes.c_int * len(elemBlkIDs))()
             elem_blk_ids[:] = elemBlkIDs
-            num_elem_this_blk = (c_int * len(elemBlkIDs))()
+            num_elem_this_blk = (ctypes.c_int * len(elemBlkIDs))()
             num_elem_this_blk[:] = numElemThisBlk
-            num_nodes_per_elem = (c_int * len(elemBlkIDs))()
+            num_nodes_per_elem = (ctypes.c_int * len(elemBlkIDs))()
             num_nodes_per_elem[:] = numNodesPerElem
-            num_attr = (c_int * len(elemBlkIDs))()
+            num_attr = (ctypes.c_int * len(elemBlkIDs))()
             num_attr[:] = numAttr
-        elem_type = (c_char_p * len(elemBlkIDs))()
+        elem_type = (ctypes.c_char_p * len(elemBlkIDs))()
         elem_type[:] = elemType
-        define_maps = c_int(defineMaps)
+        define_maps = ctypes.c_int(defineMaps)
         EXODUS_LIB.ex_put_concat_elem_block(
             self.fileId,
             elem_blk_ids,
@@ -4266,8 +4266,8 @@ class exodus:
     # --------------------------------------------------------------------
 
     def __ex_get_qa(self):
-        num_qa_recs = c_int(self.__ex_inquire_int(ex_inquiry_map('EX_INQ_QA')))
-        qa_rec_ptrs = ((POINTER(c_char * (MAX_STR_LENGTH + 1)) * 4) * num_qa_recs.value)()
+        num_qa_recs = ctypes.c_int(self.__ex_inquire_int(ex_inquiry_map('EX_INQ_QA')))
+        qa_rec_ptrs = ((POINTER(ctypes.c_char * (MAX_STR_LENGTH + 1)) * 4) * num_qa_recs.value)()
         for i in range(num_qa_recs.value):
             for j in range(4):
                 qa_rec_ptrs[i][j] = pointer(


### PR DESCRIPTION
fixed a discrepancy with the versioning.

changed the ctype to be explicit,  ` from ctypes import *` to `import ctypes` which is better practice.

could also have only imported the relevant functions, but if enough are used to use `*` then using explicitly makes the most sense I think.