### PR TITLE
exodus: avoid a linker error about duplicate symbols

### DIFF
--- a/packages/seacas/libraries/exodus/src/ex_create_par.c
+++ b/packages/seacas/libraries/exodus/src/ex_create_par.c
@@ -216,5 +216,5 @@ int ex_create_par_int(const char *path, int cmode, int *comp_ws, int *io_ws, MPI
  * Prevent warning in some versions of ranlib(1) because the object
  * file has no symbols.
  */
-const char exodus_unused_symbol_dummy_1;
+const char exodus_unused_symbol_dummy_ex_create_par;
 #endif

--- a/packages/seacas/libraries/exodus/src/ex_open_par.c
+++ b/packages/seacas/libraries/exodus/src/ex_open_par.c
@@ -459,5 +459,5 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
  * Prevent warning in some versions of ranlib(1) because the object
  * file has no symbols.
  */
-const char exodus_unused_symbol_dummy_1;
+const char exodus_unused_symbol_dummy_ex_open_par;
 #endif


### PR DESCRIPTION
GCC 10 is now stricter it seems.