### PR TITLE
SEACAS: Set test dependencies using result of ADDED_TEST_NAMES_OUT args (ATDV-183)

### DIFF
--- a/packages/seacas/libraries/exodus/test/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus/test/CMakeLists.txt
@@ -44,6 +44,7 @@ TRIBITS_ADD_TEST(
 	COMM mpi serial
 	NUM_MPI_PROCS 1
 	ARGS "CreateEdgeFace -pcab -pcset -pvpax"
+        ADDED_TESTS_NAMES_OUT CreateEdgeFaceWithConcatsAddedName
 )
 
 TRIBITS_ADD_TEST(
@@ -52,14 +53,13 @@ TRIBITS_ADD_TEST(
 	COMM mpi serial
 	NUM_MPI_PROCS 1
 	ARGS ReadEdgeFace
+        ADDED_TESTS_NAMES_OUT ReadEdgeFaceWithConcatsAddedName
 )
 
-# Should be a better way to do this, but...
-if (TPL_ENABLE_MPI)
-  set_property(TEST ${PACKAGE_NAME}_ReadEdgeFaceWithConcats_MPI_1 APPEND PROPERTY DEPENDS ${PACKAGE_NAME}_CreateEdgeFaceWithConcats_MPI_1)
-ELSE()
-  set_property(TEST ${PACKAGE_NAME}_ReadEdgeFaceWithConcats APPEND PROPERTY DEPENDS ${PACKAGE_NAME}_CreateEdgeFaceWithConcats)
-ENDIF()
+if (CreateEdgeFaceWithConcatsAddedName AND ReadEdgeFaceWithConcatsAddedName)
+  set_property(TEST ${ReadEdgeFaceWithConcatsAddedName}
+   APPEND PROPERTY DEPENDS ${CreateEdgeFaceWithConcatsAddedName})
+endif()
 
 # ===============================================
 


### PR DESCRIPTION
This only sets the test properties if the tests get added and it makes the code much more simple and robust to maintain.  (There was a better way :-) )  See:

* https://tribits.org/doc/TribitsDevelopersGuide.html#setting-additional-test-properties-tribits-add-test

This has to be done or you get a configure error when you configure with the new option [`<Project>_SKIP_CTEST_ADD_TEST=ON`](https://tribits.org/doc/TribitsBuildReference.html#disabling-just-the-ctest-tests-but-not-the-test-executables). (See TriBITSPub/TriBITS#317 and [ATDV-183](https://sems-atlassian-srn.sandia.gov/browse/ATDV-183).)

This patch is also applied in the Trilinos PR:

* https://github.com/trilinos/Trilinos/pull/7325

in the commit:

* https://github.com/trilinos/Trilinos/pull/7325/commits/8090c235a2e665e14222729d1ac3a36fc24ae265

so this has to be applied to this SEACAS git repo or the next time that the SEACAS snapshot is updated to Trilinos it will wipe out this change.
