### PR TITLE
IOSS: Add environment variable to set common_nodes to 2

### DIFF
--- a/packages/seacas/IossProperties.md
+++ b/packages/seacas/IossProperties.md
@@ -28,6 +28,7 @@ RETAIN\_FREE\_NODES | \[on]/off | In auto-decomp, will nodes not connected to an
 RETAIN\_EMPTY\_BLOCKS | on/\[off] | Empty blocks will / won't be retained in model. If retained, will have topology type "unknown".
 LOAD\_BALANCE\_THRESHOLD | {real} \[1.4] | CGNS-Structured only -- Load imbalance permitted Load on Proc / Avg Load
 LINE\_DECOMPOSITION | string | a list of comma-separated BC names. Zone with this bc will not be decomposed perpendicular to this surface. If name is `__ordinal_{ijk}` then use {ijk} as ordinal not to decompose.
+PARMETIS_COMMON_NODE_COUNT | {int}\[varies] | The degree of connectivity among the vertices in the dual graph for the ParMetis KWAY decomposition schemes. A value of 2 will permit edge connectivity in the decomposition; 3 or 4 will give face connectivity. Default is face connectivity.
 
 ### Valid values for Decomposition Method
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
@@ -135,12 +135,6 @@ namespace {
     Ioss::ParallelUtils par_util(comm);
     common_nodes = par_util.global_minmax(common_nodes, Ioss::ParallelUtils::DO_MIN);
 
-    // Overwrite common_nodes if user wants to set it to 2
-    char *envVar = getenv("IOSS_PARMETIS_TWO_COMMON_NODES");
-    if(envVar != nullptr && common_nodes > 2) {
-      common_nodes = 2;
-    }
-
 #if IOSS_DEBUG_OUTPUT
     fmt::print(Ioss::DEBUG(), "Setting common_nodes to {}\n", common_nodes);
 #endif

--- a/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
@@ -185,6 +185,10 @@ namespace Ioss {
     if (!m_showProgress) {
       Utils::check_set_bool_property(props, "ENABLE_TRACING", m_showProgress);
     }
+
+    if (props.exists("PARMETIS_COMMON_NODE_COUNT") && props.get("PARMETIS_COMMON_NODE_COUNT").get_int() > 0) {
+      m_commonNodeCount = props.get("PARMETIS_COMMON_NODE_COUNT").get_int();
+    }
   }
 
   template void Decomposition<int>::generate_entity_distributions(size_t globalNodeCount,
@@ -720,7 +724,7 @@ namespace Ioss {
     idx_t *elm_wgt      = nullptr;
     idx_t  ncon         = 1;
     idx_t  num_flag     = 0; // Use C-based numbering
-    idx_t  common_nodes = get_common_node_count(el_blocks, m_comm);
+    idx_t common_nodes = m_commonNodeCount > 0 ? m_commonNodeCount : get_common_node_count(el_blocks, m_comm);
 
     idx_t               nparts = m_processorCount;
     idx_t               ndims  = m_spatialDimension;

--- a/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
@@ -135,6 +135,12 @@ namespace {
     Ioss::ParallelUtils par_util(comm);
     common_nodes = par_util.global_minmax(common_nodes, Ioss::ParallelUtils::DO_MIN);
 
+    // Overwrite common_nodes if user wants to set it to 2
+    char *envVar = getenv("IOSS_PARMETIS_TWO_COMMON_NODES");
+    if(envVar != nullptr && common_nodes > 2) {
+      common_nodes = 2;
+    }
+
 #if IOSS_DEBUG_OUTPUT
     fmt::print(Ioss::DEBUG(), "Setting common_nodes to {}\n", common_nodes);
 #endif

--- a/packages/seacas/libraries/ioss/src/Ioss_Decomposition.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Decomposition.h
@@ -549,6 +549,7 @@ namespace Ioss {
 
     // Values for the file decomposition
     int    m_spatialDimension{3};
+    int    m_commonNodeCount{0};
     size_t m_globalElementCount{0};
     size_t m_elementCount{0};
     size_t m_elementOffset{0};


### PR DESCRIPTION
@gdsjaar 

This is a matching PR for https://github.com/trilinos/Trilinos/pull/7812

This PR adds the option of using common_nodes=2, which will be used when constructing the dual graph in ParMETIS_V3_PartMeshKway. When common_nodes=2, elements which share a common edge are connected in the dual graph. This will increase the number of connections in the dual graph (unless the elements are triangular), so captures the total communication volume more correctly in the case of an edge-based discretization.

I obtained up to 10% improvement in the solve time when I used common_nodes=2 on a tetrahedral mesh.