### PR TITLE
Add virtual destructor to SetItem

### DIFF
--- a/packages/seacas/libraries/ioss/src/main/glob.h
+++ b/packages/seacas/libraries/ioss/src/main/glob.h
@@ -310,6 +310,7 @@ namespace glob {
   {
   public:
     SetItem() = default;
+    virtual ~SetItem() = default;
 
     virtual bool Check(charT c) const = 0;
   };


### PR DESCRIPTION
this is needed in order to call delete
on SetItem base class pointers, which
SEACAS does.