### PR TITLE
APREPRO: Add --require_defined flag to treat undefined var as error

### DIFF
--- a/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
@@ -425,6 +425,9 @@ namespace SEAMS {
       ap_options.errors_and_warnings_fatal = true;
       ap_options.errors_fatal              = true;
     }
+    else if (option == "--require_defined" || option == "-R") {
+      ap_options.require_defined = true;
+    }
     else if (option == "--trace" || option == "-t") {
       ap_options.trace_parsing = true;
     }
@@ -494,6 +497,7 @@ namespace SEAMS {
              "encountered\n"
           << " --errors_and_warnings_fatal or -F: Exit program with nonzero status if "
              "warnings are encountered\n"
+          << "--require_defined or -R: Tread undefined variable warnings as fatal\n"
           << "--one_based_index or -1: Array indexing is one-based (default = zero-based)\n"
           << "    --interactive or -i: Interactive use, no buffering           \n"
           << "    --include=P or -I=P: Include file or include path            \n"

--- a/packages/seacas/libraries/aprepro_lib/apr_util.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_util.cc
@@ -139,7 +139,12 @@ namespace SEAMS {
   void undefined_error(const SEAMS::Aprepro &apr, const std::string &var)
   {
     if (!apr.inIfdefGetvar) {
-      apr.warning("Undefined variable '" + var + "'");
+      if (apr.ap_options.require_defined) {
+        apr.error("Undefined variable '" + var + "'");
+      }
+      else {
+        apr.warning("Undefined variable '" + var + "'");
+      }
     }
     else {
       apr.inIfdefGetvar = false;

--- a/packages/seacas/libraries/aprepro_lib/aprepro.h
+++ b/packages/seacas/libraries/aprepro_lib/aprepro.h
@@ -114,6 +114,7 @@ namespace SEAMS {
     bool        end_on_exit{false};
     bool        errors_fatal{false};
     bool        errors_and_warnings_fatal{false};
+    bool        require_defined{false}; // flag to treat undefined vars as errors
     bool        warning_msg{true};
     bool        info_msg{false};
     bool        debugging{false};


### PR DESCRIPTION
Pull over Sierra/SD generated PR to the seacas github repository.