### PR TITLE
Increase size of magic array for null character

### DIFF
--- a/packages/seacas/libraries/exodus/src/ex_utils.c
+++ b/packages/seacas/libraries/exodus/src/ex_utils.c
@@ -173,7 +173,7 @@ int ex__check_file_type(const char *path, int *type)
 
 #define MAGIC_NUMBER_LEN 4
 
-  char magic[MAGIC_NUMBER_LEN];
+  char magic[MAGIC_NUMBER_LEN+1];
   EX_FUNC_ENTER();
 
   *type = 0;


### PR DESCRIPTION
this prevents out of bounds access when the fifth
character is set to the null character for later
printing: the array needs to be five characters
long.