### PR TITLE
EXODIFF: add Edge Block and Face Block capabilities to exodiff

### DIFF
--- a/packages/seacas/applications/exodiff/CMakeLists.txt
+++ b/packages/seacas/applications/exodiff/CMakeLists.txt
@@ -17,5 +17,43 @@ TRIBITS_ADD_EXECUTABLE(
   INSTALLABLE
   )
 
-TRIBITS_SUBPACKAGE_POSTPROCESS()
+TRIBITS_ADD_EXECUTABLE(
+  test_generate_exo_files
+  NOEXEPREFIX
+  NOEXESUFFIX
+  SOURCES test_generate_exo_files.c
+  COMM serial mpi
+  )
 
+IF (${CMAKE_PROJECT_NAME}_ENABLE_TESTS)
+IF (${CMAKE_PROJECT_NAME}_ENABLE_SEACASExodus)
+
+TRIBITS_ADD_ADVANCED_TEST(
+ exodiff_test_edge_face
+ TEST_0 EXEC ${CMAKE_CURRENT_BINARY_DIR}/test_generate_exo_files
+        NOEXEPREFIX NOEXESUFFIX
+ TEST_1 CMND ${CMAKE_CURRENT_BINARY_DIR}/exodiff 
+        ARGS ${CMAKE_CURRENT_BINARY_DIR}/edge-face-gold.exo
+		         ${CMAKE_CURRENT_BINARY_DIR}/edge-face-no-diff.exo
+		    OUTPUT_FILE exodiff-no-diff.stdout
+		    PASS_REGULAR_EXPRESSION "exodiff: Files are the same"
+ TEST_2 CMND ${CMAKE_CURRENT_BINARY_DIR}/exodiff 
+        ARGS ${CMAKE_CURRENT_BINARY_DIR}/edge-face-gold.exo
+		         ${CMAKE_CURRENT_BINARY_DIR}/edge-diff.exo
+		    OUTPUT_FILE exodiff-edge-diff.stdout
+		    PASS_REGULAR_EXPRESSION "exodiff: Files are different"
+ TEST_3 CMND ${CMAKE_CURRENT_BINARY_DIR}/exodiff 
+        ARGS ${CMAKE_CURRENT_BINARY_DIR}/edge-face-gold.exo
+		         ${CMAKE_CURRENT_BINARY_DIR}/face-diff.exo
+		    OUTPUT_FILE exodiff-face-diff.stdout
+		    PASS_REGULAR_EXPRESSION "exodiff: Files are different"
+ COMM mpi serial
+ OVERALL_NUM_MPI_PROCS 1
+ FINAL_PASS_REGULAR_EXPRESSION
+ XHOSTTYPE Windows
+)
+
+endif()
+endif()
+
+TRIBITS_SUBPACKAGE_POSTPROCESS()

--- a/packages/seacas/applications/exodiff/ED_SystemInterface.C
+++ b/packages/seacas/applications/exodiff/ED_SystemInterface.C
@@ -503,6 +503,8 @@ void SystemInterface::Set_Max_Names(int size)
   elmt_att.resize(max_number_of_names, default_tol);
   ns_var.resize(max_number_of_names, default_tol);
   ss_var.resize(max_number_of_names, default_tol);
+  eb_var.resize(max_number_of_names, default_tol);
+  fb_var.resize(max_number_of_names, default_tol);
 }
 
 bool SystemInterface::parse_options(int argc, char **argv)
@@ -881,6 +883,8 @@ bool SystemInterface::parse_options(int argc, char **argv)
     elmt_att_default = default_tol;
     ns_var_default   = default_tol;
     ss_var_default   = default_tol;
+    eb_var_default   = default_tol;
+    fb_var_default   = default_tol;
 
     const char *temp = options_.retrieve("file");
     if (temp != nullptr) {
@@ -912,6 +916,8 @@ bool SystemInterface::parse_options(int argc, char **argv)
         elmt_att_do_all_flag = true;
         ns_var_do_all_flag   = true;
         ss_var_do_all_flag   = true;
+        eb_var_do_all_flag   = true;
+        fb_var_do_all_flag   = true;
       }
     }
   }
@@ -1404,6 +1410,36 @@ void SystemInterface::Parse_Command_File()
             ss_df_tol.floor = To_Double(tok2);
           }
         }
+      }
+      else if (abbreviation(tok1, "edgeblock", 4) && abbreviation(tok2, "variables", 3)) {
+        eb_var_default = default_tol;
+        xline = Parse_Variables(xline, cmd_file, eb_var_do_all_flag, eb_var_default, eb_var_names,
+                                eb_var, max_number_of_names);
+
+        Check_Parsed_Names(eb_var_names, eb_var_do_all_flag);
+
+        if (!xline.empty()) {
+          copy_string(line, xline);
+        }
+        else {
+          copy_string(line, "");
+        }
+        continue;
+      }
+      else if (abbreviation(tok1, "faceblock", 4) && abbreviation(tok2, "variables", 3)) {
+        fb_var_default = default_tol;
+        xline = Parse_Variables(xline, cmd_file, fb_var_do_all_flag, fb_var_default, fb_var_names,
+                                fb_var, max_number_of_names);
+
+        Check_Parsed_Names(fb_var_names, fb_var_do_all_flag);
+
+        if (!xline.empty()) {
+          copy_string(line, xline);
+        }
+        else {
+          copy_string(line, "");
+        }
+        continue;
       }
       else if (abbreviation(tok1, "element", 4) && abbreviation(tok2, "attributes", 3)) {
         elmt_att_default = default_tol;

--- a/packages/seacas/applications/exodiff/ED_SystemInterface.h
+++ b/packages/seacas/applications/exodiff/ED_SystemInterface.h
@@ -73,6 +73,14 @@ public:
   Tolerance                ss_var_default{ToleranceMode::RELATIVE_, 1.0e-6, 0.0};
   std::vector<Tolerance>   ss_var;
 
+  std::vector<std::string> eb_var_names;
+  Tolerance                eb_var_default{ToleranceMode::RELATIVE_, 1.0e-6, 0.0};
+  std::vector<Tolerance>   eb_var;
+
+  std::vector<std::string> fb_var_names;
+  Tolerance                fb_var_default{ToleranceMode::RELATIVE_, 1.0e-6, 0.0};
+  std::vector<Tolerance>   fb_var;
+
   // time step exclusion data
   std::vector<int> exclude_steps;
 
@@ -127,6 +135,8 @@ public:
   bool elmt_att_do_all_flag{false};
   bool ns_var_do_all_flag{false};
   bool ss_var_do_all_flag{false};
+  bool eb_var_do_all_flag{false};
+  bool fb_var_do_all_flag{false};
 
 private:
   void          enroll_options();

--- a/packages/seacas/applications/exodiff/MinMaxData.h
+++ b/packages/seacas/applications/exodiff/MinMaxData.h
@@ -6,14 +6,16 @@
 #include <cmath>
 
 enum class ToleranceType {
-  mm_unknown = 0,
-  mm_time    = 1, // Only val and step valid.
-  mm_global  = 2, // Only val and step valid.
-  mm_nodal   = 3, // Only val, step, and id valid.
-  mm_element = 4, // All fields valid for the rest.
-  mm_sideset = 5,
-  mm_nodeset = 6,
-  mm_elematt = 7 // step not valid
+  mm_unknown   = 0,
+  mm_time      = 1, // Only val and step valid.
+  mm_global    = 2, // Only val and step valid.
+  mm_nodal     = 3, // Only val, step, and id valid.
+  mm_element   = 4, // All fields valid for the rest.
+  mm_sideset   = 5,
+  mm_nodeset   = 6,
+  mm_edgeblock = 7,
+  mm_faceblock = 8,
+  mm_elematt   = 9 // step not valid
 };
 
 class DiffData

--- a/packages/seacas/applications/exodiff/create_file.C
+++ b/packages/seacas/applications/exodiff/create_file.C
@@ -72,6 +72,16 @@ void Build_Variable_Names(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, bool *
   build_variable_names("sideset", interFace.ss_var_names, interFace.ss_var,
                        interFace.ss_var_default, interFace.ss_var_do_all_flag, file1.SS_Var_Names(),
                        file2.SS_Var_Names(), diff_found);
+
+  // Build (and compare) edgeblock variable names.
+  build_variable_names("edgeblock", interFace.eb_var_names, interFace.eb_var,
+                       interFace.eb_var_default, interFace.eb_var_do_all_flag, file1.EB_Var_Names(),
+                       file2.EB_Var_Names(), diff_found);
+
+  // Build (and compare) faceblock variable names.
+  build_variable_names("faceblock", interFace.fb_var_names, interFace.fb_var,
+                       interFace.fb_var_default, interFace.fb_var_do_all_flag, file1.FB_Var_Names(),
+                       file2.FB_Var_Names(), diff_found);
 }
 
 template <typename INT>
@@ -134,6 +144,8 @@ int Create_File(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, const std::strin
       output_diff_names("Element Attribute", interFace.elmt_att_names);
       output_diff_names("Nodeset", interFace.ns_var_names);
       output_diff_names("Sideset", interFace.ss_var_names);
+      output_diff_names("Edgeblock", interFace.eb_var_names);
+      output_diff_names("Faceblock", interFace.fb_var_names);
     }
     else { // The files are to be compared .. echo additional info.
       if (Tolerance::use_old_floor) {
@@ -196,6 +208,10 @@ int Create_File(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, const std::strin
           fmt::print("No Sideset Distribution Factors on either file.\n");
         }
       }
+      output_compare_names("Edgeblock", interFace.eb_var_names, interFace.eb_var, file1.Num_EB_Vars(),
+                           file2.Num_EB_Vars());
+      output_compare_names("Faceblock", interFace.fb_var_names, interFace.fb_var, file1.Num_FB_Vars(),
+                           file2.Num_FB_Vars());
     }
   }
 
@@ -214,6 +230,16 @@ int Create_File(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, const std::strin
                     file2, file1.SS_Var_Names(), file2.SS_Var_Names(), ss_truth_tab,
                     interFace.quiet_flag, diff_found);
 
+  std::vector<int> eb_truth_tab;
+  build_truth_table(EX_EDGE_BLOCK, "Edgeblock", interFace.eb_var_names, file1.Num_Edge_Blocks(), file1,
+                    file2, file1.EB_Var_Names(), file2.EB_Var_Names(), eb_truth_tab,
+                    interFace.quiet_flag, diff_found);
+
+  std::vector<int> fb_truth_tab;
+  build_truth_table(EX_FACE_BLOCK, "Faceblock", interFace.fb_var_names, file1.Num_Face_Blocks(), file1,
+                    file2, file1.FB_Var_Names(), file2.FB_Var_Names(), fb_truth_tab,
+                    interFace.quiet_flag, diff_found);
+
   // Put out the concatenated variable parameters here and then
   // put out the names....
   if (out_file_id >= 0) {
@@ -227,6 +253,8 @@ int Create_File(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, const std::strin
     output_exodus_names(out_file_id, EX_ELEM_BLOCK, interFace.elmt_var_names);
     output_exodus_names(out_file_id, EX_NODE_SET, interFace.ns_var_names);
     output_exodus_names(out_file_id, EX_SIDE_SET, interFace.ss_var_names);
+    output_exodus_names(out_file_id, EX_EDGE_BLOCK, interFace.eb_var_names);
+    output_exodus_names(out_file_id, EX_FACE_BLOCK, interFace.fb_var_names);
   }
   return out_file_id;
 }

--- a/packages/seacas/applications/exodiff/edge_block.C
+++ b/packages/seacas/applications/exodiff/edge_block.C
@@ -1,0 +1,93 @@
+// Copyright(C) 1999-2020 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#include "ED_SystemInterface.h" // for SystemInterface, etc
+#include "exodusII.h"           // for ex_set, etc
+#include "iqsort.h"             // for index_qsort
+#include "edge_block.h"
+#include "smart_assert.h" // for SMART_ASSERT
+#include <cstdlib>        // for exit
+#include <vector>         // for vector
+
+template <typename INT> Edge_Block<INT>::Edge_Block() : Exo_Entity() {}
+
+template <typename INT> Edge_Block<INT>::Edge_Block(int file_id, size_t id) : Exo_Entity(file_id, id)
+{
+  SMART_ASSERT((int)id != EX_INVALID_ID);
+}
+
+template <typename INT>
+Edge_Block<INT>::Edge_Block(int file_id, size_t id, size_t ne)
+    : Exo_Entity(file_id, id, ne)
+{
+  SMART_ASSERT(id > 0);
+}
+
+template <typename INT> Edge_Block<INT>::~Edge_Block()
+{
+  SMART_ASSERT(Check_State());
+
+  delete[] edgeIndex;
+}
+
+template <typename INT> EXOTYPE Edge_Block<INT>::exodus_type() const { return EX_EDGE_BLOCK; }
+
+template <typename INT> void Edge_Block<INT>::entity_load_params()
+{
+  int      num_attr;
+  ex_block block{};
+  block.id   = id_;
+  block.type = EX_EDGE_BLOCK;
+  int err    = ex_get_block_param(fileId, &block);
+
+  numEntity          = block.num_entry;
+  num_edges_per_elmt = block.num_edges_per_entry;
+  num_attr           = block.num_attribute;
+  elmt_type          = block.topology;
+
+  if (num_edges_per_elmt < 0 || num_attr < 0) {
+    Error(fmt::format("Exo_Block<INT>::Load_Block_Params(): Data appears corrupt for block {}!\n"
+                      "\tnum elmts          = {:n}\n"
+                      "\tnum edges per elmt = {}\n"
+                      "\tnum attributes     = {}\n"
+                      " ... Aborting...\n",
+                      numEntity, num_edges_per_elmt, num_attr));
+    exit(1);
+  }
+}
+
+template <typename INT> void Edge_Block<INT>::load_edges(const INT *elmt_map) const
+{
+  int err = 0;
+  if ((edgeIndex == nullptr) && numEntity > 0) {
+    edgeIndex = new INT[numEntity];
+    SMART_ASSERT(edgeIndex != nullptr);
+
+    for (size_t i = 0; i < numEntity; i++) {
+      edgeIndex[i] = i;
+    }
+    SMART_ASSERT(Check_State());
+  }
+}
+
+template <typename INT> size_t Edge_Block<INT>::Edge_Index(size_t position) const
+{
+  load_edges();
+  SMART_ASSERT(position < numEntity);
+  return edgeIndex[position];
+}
+
+template <typename INT> int Edge_Block<INT>::Check_State() const
+{
+  SMART_ASSERT(id_ >= EX_INVALID_ID);
+  SMART_ASSERT(!(id_ == EX_INVALID_ID && numEntity > 0));
+  SMART_ASSERT(!(id_ == EX_INVALID_ID && edgeIndex));
+
+  return 1;
+}
+
+template class Edge_Block<int>;
+template class Edge_Block<int64_t>;

--- a/packages/seacas/applications/exodiff/edge_block.h
+++ b/packages/seacas/applications/exodiff/edge_block.h
@@ -1,0 +1,46 @@
+// Copyright(C) 1999-2020 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#ifndef EDGE_BLOCK_H
+#define EDGE_BLOCK_H
+
+#include "exo_entity.h"
+#include <iostream>
+
+template <typename INT> class ExoII_Read;
+
+template <typename INT> class Edge_Block : public Exo_Entity
+{
+public:
+  Edge_Block();
+  Edge_Block(int file_id, size_t id);
+  Edge_Block(int file_id, size_t id, size_t ne);
+  ~Edge_Block() override;
+
+  size_t              Edge_Index(size_t position) const;
+
+  int    Check_State() const;
+
+private:
+  Edge_Block(const Edge_Block &);                  // Not written.
+  const Edge_Block &operator=(const Edge_Block &); // Not written.
+
+  void load_edges(const INT *elmt_map = nullptr) const;
+  void entity_load_params() override;
+
+  EXOTYPE     exodus_type() const override;
+  const char *label() const override { return "Edgeblock"; }
+  const char *short_label() const override { return "edgeblock"; }
+
+  mutable INT *   edgeIndex{nullptr};
+
+  std::string elmt_type;
+  int         num_edges_per_elmt;
+
+  friend class ExoII_Read<INT>;
+};
+
+#endif

--- a/packages/seacas/applications/exodiff/exoII_read.C
+++ b/packages/seacas/applications/exodiff/exoII_read.C
@@ -10,6 +10,9 @@
 #include "exodusII.h"  // for ex_init_params, ex_opts, etc
 #include "fmt/ostream.h"
 #include "node_set.h"     // for Node_Set
+#include "side_set.h"     // for Side_Set
+#include "edge_block.h"   // for Edge_Block
+#include "face_block.h"   // for Face_Block
 #include "smart_assert.h" // for SMART_ASSERT, Assert, etc
 #include "stringx.h"      // for chop_whitespace
 #include "util.h"         // for free_name_array, etc
@@ -136,6 +139,20 @@ template <typename INT> const std::string &ExoII_Read<INT>::SS_Var_Name(int inde
   return ss_vars[index];
 }
 
+template <typename INT> const std::string &ExoII_Read<INT>::EB_Var_Name(int index) const
+{
+  SMART_ASSERT(Check_State());
+  SMART_ASSERT(index >= 0 && (unsigned)index < eb_vars.size());
+  return eb_vars[index];
+}
+
+template <typename INT> const std::string &ExoII_Read<INT>::FB_Var_Name(int index) const
+{
+  SMART_ASSERT(Check_State());
+  SMART_ASSERT(index >= 0 && (unsigned)index < fb_vars.size());
+  return fb_vars[index];
+}
+
 template <typename INT>
 Exo_Block<INT> *ExoII_Read<INT>::Get_Elmt_Block_by_Index(size_t block_index) const
 {
@@ -176,6 +193,8 @@ Exo_Entity *ExoII_Read<INT>::Get_Entity_by_Index(EXOTYPE type, size_t block_inde
   case EX_ELEM_BLOCK: SMART_ASSERT(block_index < num_elmt_blocks); return &eblocks[block_index];
   case EX_NODE_SET: SMART_ASSERT(block_index < num_node_sets); return &nsets[block_index];
   case EX_SIDE_SET: SMART_ASSERT(block_index < num_side_sets); return &ssets[block_index];
+  case EX_EDGE_BLOCK: SMART_ASSERT(block_index < num_edge_blocks); return &edge_blocks[block_index];
+  case EX_FACE_BLOCK: SMART_ASSERT(block_index < num_face_blocks); return &face_blocks[block_index];
   default: return nullptr;
   }
 }
@@ -202,6 +221,20 @@ template <typename INT> Exo_Entity *ExoII_Read<INT>::Get_Entity_by_Id(EXOTYPE ty
     for (size_t i = 0; i < num_side_sets; i++) {
       if (ssets[i].Id() == id) {
         return &ssets[i];
+      }
+    }
+    break;
+  case EX_EDGE_BLOCK:
+    for (size_t i = 0; i < num_edge_blocks; i++) {
+      if (edge_blocks[i].Id() == id) {
+        return &edge_blocks[i];
+      }
+    }
+    break;
+  case EX_FACE_BLOCK:
+    for (size_t i = 0; i < num_face_blocks; i++) {
+      if (face_blocks[i].Id() == id) {
+        return &face_blocks[i];
       }
     }
     break;
@@ -233,6 +266,20 @@ Exo_Entity *ExoII_Read<INT>::Get_Entity_by_Name(EXOTYPE type, const std::string 
     for (size_t i = 0; i < num_side_sets; i++) {
       if (ssets[i].Name() == name) {
         return &ssets[i];
+      }
+    }
+    break;
+  case EX_EDGE_BLOCK:
+    for (size_t i = 0; i < num_edge_blocks; i++) {
+      if (edge_blocks[i].Name() == name) {
+        return &edge_blocks[i];
+      }
+    }
+    break;
+  case EX_FACE_BLOCK:
+    for (size_t i = 0; i < num_face_blocks; i++) {
+      if (face_blocks[i].Name() == name) {
+        return &face_blocks[i];
       }
     }
     break;
@@ -282,6 +329,52 @@ Side_Set<INT> *ExoII_Read<INT>::Get_Side_Set_by_Name(const std::string &name) co
   for (size_t i = 0; i < num_side_sets; i++) {
     if (ssets[i].Name() == name) {
       return &ssets[i];
+    }
+  }
+  return nullptr;
+}
+
+template <typename INT> Edge_Block<INT> *ExoII_Read<INT>::Get_Edge_Block_by_Id(size_t block_id) const
+{
+  SMART_ASSERT(Check_State());
+  for (size_t i = 0; i < num_edge_blocks; i++) {
+    if (edge_blocks[i].Id() == block_id) {
+      return &edge_blocks[i];
+    }
+  }
+  return nullptr;
+}
+
+template <typename INT>
+Edge_Block<INT> *ExoII_Read<INT>::Get_Edge_Block_by_Name(const std::string &name) const
+{
+  SMART_ASSERT(Check_State());
+  for (size_t i = 0; i < num_edge_blocks; i++) {
+    if (edge_blocks[i].Name() == name) {
+      return &edge_blocks[i];
+    }
+  }
+  return nullptr;
+}
+
+template <typename INT> Face_Block<INT> *ExoII_Read<INT>::Get_Face_Block_by_Id(size_t block_id) const
+{
+  SMART_ASSERT(Check_State());
+  for (size_t i = 0; i < num_face_blocks; i++) {
+    if (face_blocks[i].Id() == block_id) {
+      return &face_blocks[i];
+    }
+  }
+  return nullptr;
+}
+
+template <typename INT>
+Face_Block<INT> *ExoII_Read<INT>::Get_Face_Block_by_Name(const std::string &name) const
+{
+  SMART_ASSERT(Check_State());
+  for (size_t i = 0; i < num_face_blocks; i++) {
+    if (face_blocks[i].Name() == name) {
+      return &face_blocks[i];
     }
   }
   return nullptr;
@@ -719,6 +812,30 @@ Node_Set<INT> *ExoII_Read<INT>::Get_Node_Set_by_Index(size_t set_index) const
   return &nsets[set_index];
 }
 
+template <typename INT>
+Edge_Block<INT> *ExoII_Read<INT>::Get_Edge_Block_by_Index(size_t edge_block_index) const
+{
+  SMART_ASSERT(Check_State());
+
+  if (edge_block_index >= num_edge_blocks) {
+    return nullptr;
+  }
+
+  return &edge_blocks[edge_block_index];
+}
+
+template <typename INT>
+Face_Block<INT> *ExoII_Read<INT>::Get_Face_Block_by_Index(size_t face_block_index) const
+{
+  SMART_ASSERT(Check_State());
+
+  if (face_block_index >= num_face_blocks) {
+    return nullptr;
+  }
+
+  return &face_blocks[face_block_index];
+}
+
 // **********************  Misc functions  *************************** //
 
 // This function converts an Exodus global element number (1-offset) into
@@ -863,6 +980,8 @@ template <typename INT> void ExoII_Read<INT>::Get_Init_Data()
   num_elmt_blocks = info.num_elem_blk;
   num_node_sets   = info.num_node_sets;
   num_side_sets   = info.num_side_sets;
+  num_edge_blocks = info.num_edge_blk;
+  num_face_blocks = info.num_face_blk;
   title           = info.title;
 
   if (err > 0 && !interFace.quiet_flag) {
@@ -876,9 +995,11 @@ template <typename INT> void ExoII_Read<INT>::Get_Init_Data()
                       "         num_elmt_blocks = {}\n"
                       "         num_node_sets = {}\n"
                       "         num_side_sets = {}\n"
+                      "         num_edge_blocks = {}\n"
+                      "         num_face_blocks = {}\n"
                       " ... Aborting...\n",
                       dimension, num_nodes, num_elmts, num_elmt_blocks, num_node_sets,
-                      num_side_sets));
+                      num_edge_blocks, num_face_blocks, num_side_sets));
     exit(1);
   }
 
@@ -1018,9 +1139,69 @@ template <typename INT> void ExoII_Read<INT>::Get_Init_Data()
     }
   }
 
+  //                     Edge & Face blocks...
+
+  if (edge_blocks) {
+    delete[] edge_blocks;
+  }
+  edge_blocks = nullptr;
+  if (num_edge_blocks > 0) {
+    edge_blocks = new Edge_Block<INT>[num_edge_blocks];
+    SMART_ASSERT(edge_blocks != nullptr);
+    std::vector<INT> ids(num_edge_blocks);
+
+    err = ex_get_ids(file_id, EX_EDGE_BLOCK, ids.data());
+
+    if (err < 0) {
+      Error("Failed to get edgeblock ids!  Aborting...\n");
+      exit(1);
+    }
+
+    for (size_t edge_block = 0; edge_block < num_edge_blocks; ++edge_block) {
+      if (ids[edge_block] <= EX_INVALID_ID) {
+        fmt::print(stderr,
+                   "EXODIFF  WARNING: Edgeblock Id "
+                   "for edgeblock index {} is {}"
+                   " which is negative.  This was returned by call to ex_get_ids().\n",
+                   edge_block, ids[edge_block]);
+      }
+
+      edge_blocks[edge_block].initialize(file_id, ids[edge_block]);
+    }
+  }
+
+  if (face_blocks) {
+    delete[] face_blocks;
+  }
+  face_blocks = nullptr;
+  if (num_face_blocks > 0) {
+    face_blocks = new Face_Block<INT>[num_face_blocks];
+    SMART_ASSERT(face_blocks != nullptr);
+    std::vector<INT> ids(num_face_blocks);
+
+    err = ex_get_ids(file_id, EX_FACE_BLOCK, ids.data());
+
+    if (err < 0) {
+      Error("Failed to get faceblock ids!  Aborting...\n");
+      exit(1);
+    }
+
+    for (size_t face_block = 0; face_block < num_face_blocks; ++face_block) {
+      if (ids[face_block] <= EX_INVALID_ID) {
+        fmt::print(stderr,
+                   "EXODIFF  WARNING: Faceblock Id "
+                   "for faceblock index {} is {}"
+                   " which is negative.  This was returned by call to ex_get_ids().\n",
+                   face_block, ids[face_block]);
+      }
+
+      face_blocks[face_block].initialize(file_id, ids[face_block]);
+    }
+  }
+
   //  **************  RESULTS info  ***************  //
 
-  int num_global_vars, num_nodal_vars, num_elmt_vars, num_ns_vars, num_ss_vars;
+  int num_global_vars, num_nodal_vars, num_elmt_vars, num_ns_vars, num_ss_vars, num_edge_vars, num_face_vars;
 
   err = ex_get_variable_param(file_id, EX_GLOBAL, &num_global_vars);
   if (err < 0) {
@@ -1052,15 +1233,32 @@ template <typename INT> void ExoII_Read<INT>::Get_Init_Data()
     exit(1);
   }
 
+  err = ex_get_variable_param(file_id, EX_EDGE_BLOCK, &num_edge_vars);
+  if (err < 0) {
+    Error("Failed to get number of edgeblock variables!  Aborting...\n");
+    exit(1);
+  }
+
+  err = ex_get_variable_param(file_id, EX_FACE_BLOCK, &num_face_vars);
+  if (err < 0) {
+    Error("Failed to get number of faceblock variables!  Aborting...\n");
+    exit(1);
+  }
+
   if (num_global_vars < 0 || num_nodal_vars < 0 || num_elmt_vars < 0 || num_ns_vars < 0 ||
-      num_ss_vars < 0) {
+      num_ss_vars < 0 || num_edge_vars < 0 || num_face_vars < 0) {
     Error(fmt::format("Data appears corrupt for"
                       " number of variables !\n"
                       "\tnum global vars  = {}\n"
                       "\tnum nodal vars   = {}\n"
                       "\tnum element vars = {}\n"
+                      "\tnum nodeset vars = {}\n"
+                      "\tnum sideset vars = {}\n"
+                      "\tnum edgeblock vars = {}\n"
+                      "\tnum faceblock vars = {}\n"
                       " ... Aborting...\n",
-                      num_global_vars, num_nodal_vars, num_elmt_vars));
+                      num_global_vars, num_nodal_vars, num_elmt_vars, 
+                      num_ns_vars, num_ss_vars, num_edge_vars, num_face_vars));
     exit(1);
   }
 
@@ -1069,6 +1267,8 @@ template <typename INT> void ExoII_Read<INT>::Get_Init_Data()
   read_vars(file_id, EX_ELEM_BLOCK, "Element", num_elmt_vars, elmt_vars);
   read_vars(file_id, EX_NODE_SET, "Nodeset", num_ns_vars, ns_vars);
   read_vars(file_id, EX_SIDE_SET, "Sideset", num_ss_vars, ss_vars);
+  read_vars(file_id, EX_EDGE_BLOCK, "Edgeblock", num_edge_vars, eb_vars);
+  read_vars(file_id, EX_FACE_BLOCK, "Faceblock", num_face_vars, fb_vars);
 
   // Times:
   num_times = ex_inquire_int(file_id, EX_INQ_TIME);
@@ -1078,7 +1278,7 @@ template <typename INT> void ExoII_Read<INT>::Get_Init_Data()
   }
 
   if ((num_global_vars > 0 || num_nodal_vars > 0 || num_elmt_vars > 0 || num_ns_vars > 0 ||
-       num_ss_vars > 0) &&
+       num_ss_vars > 0 || num_edge_vars > 0 || num_face_vars > 0) &&
       num_times == 0) {
     Error("Consistency error -- The database contains transient variables, but no "
           "timesteps!\n");

--- a/packages/seacas/applications/exodiff/exoII_read.h
+++ b/packages/seacas/applications/exodiff/exoII_read.h
@@ -29,6 +29,9 @@ template <typename INT> class Exo_Block;
 template <typename INT> class Node_Set;
 template <typename INT> class Side_Set;
 
+template <typename INT> class Edge_Block;
+template <typename INT> class Face_Block;
+
 template <typename INT> class ExoII_Read
 {
 public:
@@ -56,6 +59,8 @@ public:
   size_t             Num_Elmts() const { return num_elmts; }
   size_t             Num_Node_Sets() const { return num_node_sets; }
   size_t             Num_Side_Sets() const { return num_side_sets; }
+  size_t             Num_Edge_Blocks() const { return num_edge_blocks; }
+  size_t             Num_Face_Blocks() const { return num_face_blocks; }
 
   // Times:
 
@@ -70,18 +75,25 @@ public:
   size_t                          Num_Elmt_Atts() const { return elmt_atts.size(); }
   size_t                          Num_NS_Vars() const { return ns_vars.size(); }
   size_t                          Num_SS_Vars() const { return ss_vars.size(); }
+  size_t                          Num_EB_Vars() const { return eb_vars.size(); }
+  size_t                          Num_FB_Vars() const { return fb_vars.size(); }
   const std::vector<std::string> &Global_Var_Names() const { return global_vars; }
   const std::vector<std::string> &Nodal_Var_Names() const { return nodal_vars; }
   const std::vector<std::string> &Elmt_Var_Names() const { return elmt_vars; }
   const std::vector<std::string> &Elmt_Att_Names() const { return elmt_atts; }
   const std::vector<std::string> &NS_Var_Names() const { return ns_vars; }
   const std::vector<std::string> &SS_Var_Names() const { return ss_vars; }
+  const std::vector<std::string> &EB_Var_Names() const { return eb_vars; }
+  const std::vector<std::string> &FB_Var_Names() const { return fb_vars; }
+
   const std::string &             Global_Var_Name(int index) const;
   const std::string &             Nodal_Var_Name(int index) const;
   const std::string &             Elmt_Var_Name(int index) const;
   const std::string &             Elmt_Att_Name(int index) const;
   const std::string &             NS_Var_Name(int index) const;
   const std::string &             SS_Var_Name(int index) const;
+  const std::string &             EB_Var_Name(int index) const;
+  const std::string &             FB_Var_Name(int index) const;
 
   // Element blocks:
   size_t Num_Elmt_Blocks() const { return num_elmt_blocks; }
@@ -160,6 +172,14 @@ public:
   Node_Set<INT> *Get_Node_Set_by_Index(size_t set_index) const;
   Node_Set<INT> *Get_Node_Set_by_Name(const std::string &name) const;
 
+  Edge_Block<INT> *Get_Edge_Block_by_Id(size_t block_id) const;
+  Edge_Block<INT> *Get_Edge_Block_by_Index(size_t set_index) const;
+  Edge_Block<INT> *Get_Edge_Block_by_Name(const std::string &name) const;
+
+  Face_Block<INT> *Get_Face_Block_by_Id(size_t block_id) const;
+  Face_Block<INT> *Get_Face_Block_by_Index(size_t set_index) const;
+  Face_Block<INT> *Get_Face_Block_by_Name(const std::string &name) const;
+
   // Misc functions:
 
   virtual int Check_State() const;                           // Checks state of obj (not the file).
@@ -182,6 +202,8 @@ protected:
   size_t                   num_elmt_blocks{0};
   size_t                   num_node_sets{0};
   size_t                   num_side_sets{0};
+  size_t                   num_edge_blocks{0};
+  size_t                   num_face_blocks{0};
   float                    db_version{0.0};
   float                    api_version{0.0};
   int                      io_word_size{0}; // Note: The "compute word size" is always 8.
@@ -189,6 +211,8 @@ protected:
   Exo_Block<INT> *eblocks{nullptr}; // Array.
   Node_Set<INT> * nsets{nullptr};   // Array.
   Side_Set<INT> * ssets{nullptr};   // Array.
+  Edge_Block<INT> * edge_blocks{nullptr};   // Array.
+  Face_Block<INT> * face_blocks{nullptr};   // Array.
 
   double *nodes{nullptr}; // Matrix;  dimension by num_nodes (row major form).
                           //          I.e., all x's then all y's, etc.
@@ -205,6 +229,8 @@ protected:
   std::vector<std::string> elmt_atts;
   std::vector<std::string> ns_vars;
   std::vector<std::string> ss_vars;
+  std::vector<std::string> eb_vars;
+  std::vector<std::string> fb_vars;
 
   int     num_times{0};
   double *times{nullptr};

--- a/packages/seacas/applications/exodiff/exo_entity.C
+++ b/packages/seacas/applications/exodiff/exo_entity.C
@@ -452,6 +452,8 @@ namespace {
     case EX_ELEM_BLOCK: inquiry = EX_INQ_ELEM_BLK; break;
     case EX_NODE_SET: inquiry = EX_INQ_NODE_SETS; break;
     case EX_SIDE_SET: inquiry = EX_INQ_SIDE_SETS; break;
+    case EX_EDGE_BLOCK: inquiry = EX_INQ_EDGE_BLK; break;
+    case EX_FACE_BLOCK: inquiry = EX_INQ_FACE_BLK; break;
     default: Error("Invalid entity type in get_num_entities\n"); exit(1);
     }
     SMART_ASSERT(inquiry != EX_INQ_INVALID);

--- a/packages/seacas/applications/exodiff/exodiff.C
+++ b/packages/seacas/applications/exodiff/exodiff.C
@@ -28,6 +28,8 @@
 #include "map.h"
 #include "node_set.h"
 #include "side_set.h"
+#include "edge_block.h"
+#include "face_block.h"
 #include "smart_assert.h"
 #include "stringx.h"
 #include "util.h"
@@ -129,7 +131,9 @@ template <typename INT>
 void do_diffs(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, int time_step1, const TimeInterp &t2,
               int out_file_id, std::vector<MinMaxData> &mm_glob, std::vector<MinMaxData> &mm_node,
               std::vector<MinMaxData> &mm_elmt, std::vector<MinMaxData> &mm_ns,
-              std::vector<MinMaxData> &mm_ss, INT *node_map, const INT *node_id_map, INT *elmt_map,
+              std::vector<MinMaxData> &mm_ss, 
+              std::vector<MinMaxData> &mm_eb, std::vector<MinMaxData> &mm_fb,
+              INT *node_map, const INT *node_id_map, INT *elmt_map,
               const INT *elem_id_map, Exo_Block<INT> **blocks2, double *var_vals, bool *diff_flag);
 
 template <typename INT>
@@ -163,6 +167,7 @@ template <typename INT>
 void output_summary(ExoII_Read<INT> &file1, MinMaxData &mm_time, std::vector<MinMaxData> &mm_glob,
                     std::vector<MinMaxData> &mm_node, std::vector<MinMaxData> &mm_elmt,
                     std::vector<MinMaxData> &mm_ns, std::vector<MinMaxData> &mm_ss,
+                    std::vector<MinMaxData> &mm_eb, std::vector<MinMaxData> &mm_fb,
                     const INT *node_id_map, const INT *elem_id_map);
 
 #include <csignal>
@@ -267,11 +272,12 @@ namespace {
     fmt::print("{0}  FILE {15}: {1}\n"
                "{0}   Title: {2}\n"
                "{0}          Dim = {3}, Blocks = {4}, Nodes = {5}, Elements = {6}, Nodesets = {7}, "
-               "Sidesets = {8}\n"
-               "{0}          Vars: Global = {9}, Nodal = {10}, Element = {11}, Nodeset = {12}, "
-               "Sideset = {13}, Times = {14}\n\n",
+               "Sidesets = {8}, Edge Blocks = {9}, Face Blocks = {10}\n"
+               "{0}          Vars: Global = {11}, Nodal = {12}, Element = {13}, Nodeset = {14}, "
+               "Sideset = {15}, Times = {16}\n\n",
                prefix, fi.realpath(), file.Title(), file.Dimension(), file.Num_Elmt_Blocks(),
                file.Num_Nodes(), file.Num_Elmts(), file.Num_Node_Sets(), file.Num_Side_Sets(),
+               file.Num_EB_Vars(), file.Num_FB_Vars(),
                file.Num_Global_Vars(), file.Num_Nodal_Vars(), file.Num_Elmt_Vars(),
                file.Num_NS_Vars(), file.Num_SS_Vars(), file.Num_Times(), count);
   }
@@ -325,6 +331,8 @@ int main(int argc, char *argv[])
     interFace.elmt_att_do_all_flag = true;
     interFace.ns_var_do_all_flag   = true;
     interFace.ss_var_do_all_flag   = true;
+    interFace.eb_var_do_all_flag   = true;
+    interFace.fb_var_do_all_flag   = true;
     interFace.map_flag             = MapType::FILE_ORDER;
     interFace.quiet_flag           = false;
   }
@@ -403,6 +411,8 @@ namespace {
         file1.Num_Nodal_Vars() > interFace.max_number_of_names ||
         file1.Num_NS_Vars() > interFace.max_number_of_names ||
         file1.Num_SS_Vars() > interFace.max_number_of_names ||
+        file1.Num_EB_Vars() > interFace.max_number_of_names ||
+        file1.Num_FB_Vars() > interFace.max_number_of_names ||
         file1.Num_Elmt_Vars() > interFace.max_number_of_names) {
       size_t max = file1.Num_Global_Vars();
       if (file1.Num_Nodal_Vars() > max) {
@@ -413,6 +423,12 @@ namespace {
       }
       if (file1.Num_SS_Vars() > max) {
         max = file1.Num_SS_Vars();
+      }
+      if (file1.Num_EB_Vars() > max) {
+        max = file1.Num_EB_Vars();
+      }
+      if (file1.Num_FB_Vars() > max) {
+        max = file1.Num_FB_Vars();
       }
       if (file1.Num_Elmt_Vars() > max) {
         max = file1.Num_Elmt_Vars();
@@ -432,6 +448,8 @@ namespace {
           file2.Num_Nodal_Vars() > interFace.max_number_of_names ||
           file2.Num_NS_Vars() > interFace.max_number_of_names ||
           file2.Num_SS_Vars() > interFace.max_number_of_names ||
+          file1.Num_EB_Vars() > interFace.max_number_of_names ||
+          file1.Num_FB_Vars() > interFace.max_number_of_names ||
           file2.Num_Elmt_Vars() > interFace.max_number_of_names) {
         size_t max = file2.Num_Global_Vars();
         if (file2.Num_Nodal_Vars() > max) {
@@ -442,6 +460,12 @@ namespace {
         }
         if (file2.Num_SS_Vars() > max) {
           max = file2.Num_SS_Vars();
+        }
+        if (file2.Num_EB_Vars() > max) {
+          max = file2.Num_EB_Vars();
+        }
+        if (file2.Num_FB_Vars() > max) {
+          max = file2.Num_FB_Vars();
         }
         if (file2.Num_Elmt_Vars() > max) {
           max = file2.Num_Elmt_Vars();
@@ -635,6 +659,8 @@ namespace {
     std::vector<MinMaxData> mm_eatt;
     std::vector<MinMaxData> mm_ns;
     std::vector<MinMaxData> mm_ss;
+    std::vector<MinMaxData> mm_eb;
+    std::vector<MinMaxData> mm_fb;
 
     if (interFace.summary_flag) {
       int n;
@@ -672,6 +698,18 @@ namespace {
         mm_ss.resize(n);
         for (int i = 0; i < n; i++) {
           mm_ss[i].type = ToleranceType::mm_sideset;
+        }
+      }
+      if ((n = interFace.eb_var_names.size()) > 0) {
+        mm_eb.resize(n);
+        for (int i = 0; i < n; i++) {
+          mm_eb[i].type = ToleranceType::mm_edgeblock;
+        }
+      }
+      if ((n = interFace.fb_var_names.size()) > 0) {
+        mm_fb.resize(n);
+        for (int i = 0; i < n; i++) {
+          mm_fb[i].type = ToleranceType::mm_faceblock;
         }
       }
     }
@@ -718,7 +756,7 @@ namespace {
         }
       }
 
-      do_diffs(file1, file2, ts1, t2, out_file_id, mm_glob, mm_node, mm_elmt, mm_ns, mm_ss,
+      do_diffs(file1, file2, ts1, t2, out_file_id, mm_glob, mm_node, mm_elmt, mm_ns, mm_ss, mm_eb, mm_fb,
                node_map, node_id_map, elmt_map, elem_id_map, blocks2, var_vals, &diff_flag);
     }
     else {
@@ -909,7 +947,7 @@ namespace {
           continue;
         }
 
-        do_diffs(file1, file2, time_step1, t2, out_file_id, mm_glob, mm_node, mm_elmt, mm_ns, mm_ss,
+        do_diffs(file1, file2, time_step1, t2, out_file_id, mm_glob, mm_node, mm_elmt, mm_ns, mm_ss, mm_eb, mm_fb,
                  node_map, node_id_map, elmt_map, elem_id_map, blocks2, var_vals, &diff_flag);
 
       } // End of time step loop.
@@ -920,7 +958,8 @@ namespace {
             (min_num_times > 0 && interFace.time_tol.type == ToleranceMode::IGNORE_ &&
              interFace.glob_var_names.empty() && interFace.node_var_names.empty() &&
              interFace.elmt_var_names.empty() && interFace.elmt_att_names.empty() &&
-             interFace.ns_var_names.empty() && interFace.ss_var_names.empty())) {
+             interFace.ns_var_names.empty() && interFace.ss_var_names.empty() &&
+             interFace.eb_var_names.empty() && interFace.fb_var_names.empty())) {
           DIFF_OUT("\nWARNING: No comparisons were performed during this execution.");
           diff_flag = true;
         }
@@ -928,8 +967,8 @@ namespace {
     }
 
     if (interFace.summary_flag) {
-      output_summary(file1, mm_time, mm_glob, mm_node, mm_elmt, mm_ns, mm_ss, node_id_map,
-                     elem_id_map);
+      output_summary(file1, mm_time, mm_glob, mm_node, mm_elmt, mm_ns, mm_ss, mm_eb, mm_fb, 
+                     node_id_map, elem_id_map);
     }
     else if (out_file_id >= 0) {
       ex_close(out_file_id);
@@ -1147,7 +1186,9 @@ template <typename INT>
 void do_diffs(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, int time_step1, const TimeInterp &t2,
               int out_file_id, std::vector<MinMaxData> &mm_glob, std::vector<MinMaxData> &mm_node,
               std::vector<MinMaxData> &mm_elmt, std::vector<MinMaxData> &mm_ns,
-              std::vector<MinMaxData> &mm_ss, INT *node_map, const INT *node_id_map, INT *elmt_map,
+              std::vector<MinMaxData> &mm_ss, 
+              std::vector<MinMaxData> &mm_eb, std::vector<MinMaxData> &mm_fb,
+              INT *node_map, const INT *node_id_map, INT *elmt_map,
               const INT *elem_id_map, Exo_Block<INT> **blocks2, double *var_vals, bool *diff_flag)
 {
   if (diff_globals(file1, file2, time_step1, t2, out_file_id, mm_glob, var_vals)) {
@@ -1176,10 +1217,21 @@ void do_diffs(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, int time_step1, co
     if (diff_sideset(file1, file2, time_step1, t2, out_file_id, elem_id_map, mm_ss, var_vals)) {
       *diff_flag = true;
     }
+
+    // Edge Block variables.
+    if (diff_edgeblock(file1, file2, time_step1, t2, out_file_id, elem_id_map, mm_eb, var_vals)) {
+      *diff_flag = true;
+    }
+
+    // Face Block variables.
+    if (diff_faceblock(file1, file2, time_step1, t2, out_file_id, elem_id_map, mm_fb, var_vals)) {
+      *diff_flag = true;
+    }
   }
   else {
-    if (!interFace.ns_var_names.empty() || !interFace.ss_var_names.empty()) {
-      fmt::print("WARNING: nodeset and sideset variables not (yet) "
+    if (!interFace.ns_var_names.empty() || !interFace.ss_var_names.empty() || 
+        !interFace.eb_var_names.empty() || !interFace.fb_var_names.empty()) {
+      fmt::print("WARNING: nodeset, sideset, edge block and face block variables not (yet) "
                  "compared for partial map\n");
     }
   }
@@ -2179,6 +2231,363 @@ bool diff_sideset_df(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, const INT *
 }
 
 template <typename INT>
+bool diff_edgeblock(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, int step1, const TimeInterp &t2,
+                  int out_file_id, const INT *id_map, std::vector<MinMaxData> &mm_eb, double *vals)
+{
+  bool diff_flag = false;
+
+  if (out_file_id >= 0) {
+    SMART_ASSERT(vals != nullptr);
+  }
+
+  int name_length = max_string_length(file1.EB_Var_Names()) + 1;
+
+  if (out_file_id < 0 && !interFace.quiet_flag && !interFace.summary_flag &&
+      !interFace.eb_var_names.empty()) {
+    fmt::print("Edge Block variables:\n");
+  }
+
+  for (unsigned e_idx = 0; e_idx < interFace.eb_var_names.size(); ++e_idx) {
+    const std::string &name  = (interFace.eb_var_names)[e_idx];
+    int                vidx1 = find_string(file1.EB_Var_Names(), name, interFace.nocase_var_names);
+    int                vidx2 = 0;
+    if (!interFace.summary_flag) {
+      vidx2 = find_string(file2.EB_Var_Names(), name, interFace.nocase_var_names);
+    }
+    if (vidx1 < 0 || vidx2 < 0) {
+      Error(fmt::format("Unable to find edgeblock variable named '{}' on database.\n", name));
+      exit(1);
+    }
+
+    DiffData max_diff;
+    Norm     norm;
+
+    for (size_t b = 0; b < file1.Num_Edge_Blocks(); ++b) {
+      Edge_Block<INT> *eblock1 = file1.Get_Edge_Block_by_Index(b);
+      SMART_ASSERT(eblock1 != nullptr);
+      if (eblock1->Size() == 0) {
+          std::cout << "eblock1->Size() == 0...continuing..." << std::endl;
+        continue;
+      }
+      if (!eblock1->is_valid_var(vidx1)) {
+        continue;
+      }
+
+      Edge_Block<INT> *eblock2 = nullptr;
+      if (!interFace.summary_flag) {
+        if (interFace.by_name) {
+          eblock2 = file2.Get_Edge_Block_by_Name(eblock1->Name());
+        }
+        else {
+          eblock2 = file2.Get_Edge_Block_by_Id(eblock1->Id());
+        }
+        if (eblock2 == nullptr || !eblock2->is_valid_var(vidx2)) {
+          continue;
+        }
+      }
+
+      eblock1->Load_Results(step1, vidx1);
+      const double *vals1 = eblock1->Get_Results(vidx1);
+
+      if (vals1 == nullptr) {
+        Error(fmt::format("Could not find variable '{}' in edgeblock {}, file 1.\n", name,
+                          eblock1->Id()));
+        diff_flag = true;
+        continue;
+      }
+
+      if (Invalid_Values(vals1, eblock1->Size())) {
+        Error(fmt::format("NaN found for edgeblock variable '{}' in edgeblock {}, file 1.\n", name,
+                          eblock1->Id()));
+        diff_flag = true;
+      }
+
+      double        v2    = 0;
+      const double *vals2 = nullptr;
+      if (!interFace.summary_flag) {
+        eblock2->Load_Results(t2.step1, t2.step2, t2.proportion, vidx2);
+        vals2 = eblock2->Get_Results(vidx2);
+
+        if (vals2 == nullptr) {
+          Error(fmt::format("Could not find variable '{}' in edgeblock {}, file 2.\n", name,
+                            eblock2->Id()));
+          diff_flag = true;
+          continue;
+        }
+
+        if (Invalid_Values(vals2, eblock2->Size())) {
+          Error(fmt::format("NaN found for edgeblock variable '{}' in edgeblock {}, file 2.\n", name,
+                            eblock2->Id()));
+          diff_flag = true;
+        }
+      }
+
+      size_t ecount = eblock1->Size();
+      if (interFace.summary_flag || eblock2->Size() == ecount) {
+        for (size_t e = 0; e < ecount; ++e) {
+          size_t ind1 = eblock1->Edge_Index(e);
+          size_t ind2 = 0;
+          if (out_file_id >= 0) {
+            vals[ind1] = 0.;
+          }
+          if (!interFace.summary_flag) {
+            ind2 = eblock2->Edge_Index(e);
+            v2   = vals2[ind2];
+          }
+
+          if (interFace.summary_flag) {
+            mm_eb[e_idx].spec_min_max(vals1[ind1], step1, e, eblock1->Id());
+          }
+          else if (out_file_id >= 0) {
+            vals[ind1] = FileDiff(vals1[ind1], v2, interFace.output_type);
+          }
+          else if (interFace.show_all_diffs) {
+            double d = interFace.eb_var[e_idx].Delta(vals1[ind1], v2);
+            if (d > interFace.eb_var[e_idx].value) {
+              diff_flag = true;
+              buf       = fmt::format(
+                  "   {:<{}} {} diff: {:14.7e} ~ {:14.7e} ={:12.5e} (block {}, edge {})", name,
+                  name_length, interFace.eb_var[e_idx].abrstr(), vals1[ind1], v2, d, eblock1->Id(),
+                  id_map[eblock1->Edge_Index(e)]);
+              DIFF_OUT(buf);
+            }
+          }
+          else {
+            double d = interFace.eb_var[e_idx].Delta(vals1[ind1], v2);
+            max_diff.set_max(d, vals1[ind1], v2, e, eblock1->Id());
+          }
+          norm.add_value(vals1[ind1], v2);
+        }
+        if (out_file_id >= 0) {
+          ex_put_var(out_file_id, t2.step1, EX_EDGE_BLOCK, e_idx + 1, eblock1->Id(), eblock1->Size(),
+                     vals);
+        }
+      }
+      else {
+        buf = fmt::format("   {:<{}}     diff: edgeblock edge counts differ for edgeblock {}", name,
+                          name_length, eblock1->Id());
+        DIFF_OUT(buf);
+        diff_flag = true;
+      }
+
+      eblock1->Free_Results();
+      if (!interFace.summary_flag) {
+        eblock2->Free_Results();
+      }
+    } // End of edgeblock loop.
+
+    if (!interFace.summary_flag && max_diff.diff > interFace.eb_var[e_idx].value) {
+      diff_flag = true;
+
+      if (interFace.doL1Norm && norm.diff(1) > 0.0) {
+        buf = fmt::format("   {:<{}} L1 norm of diff={:14.7e} ({:11.5e} ~ {:11.5e}) rel={:14.7e}",
+                          name, name_length, norm.diff(1), norm.left(1), norm.right(1),
+                          norm.relative(1));
+        DIFF_OUT(buf, fmt::color::green);
+      }
+      if (interFace.doL2Norm && norm.diff(2) > 0.0) {
+        buf = fmt::format("   {:<{}} L2 norm of diff={:14.7e} ({:11.5e} ~ {:11.5e}) rel={:14.7e}",
+                          name, name_length, norm.diff(2), norm.left(2), norm.right(2),
+                          norm.relative(2));
+        DIFF_OUT(buf, fmt::color::green);
+      }
+
+      if (!interFace.quiet_flag) {
+        Edge_Block<INT> *eblock = file1.Get_Edge_Block_by_Id(max_diff.blk);
+        buf = fmt::format("   {:<{}} {} diff: {:14.7e} ~ {:14.7e} ={:12.5e} (block {}, edge {})",
+                          name, name_length, interFace.eb_var[e_idx].abrstr(), max_diff.val1,
+                          max_diff.val2, max_diff.diff, max_diff.blk,
+                          id_map[eblock->Edge_Index(max_diff.id)]);
+        DIFF_OUT(buf);
+      }
+      else {
+        Die_TS(step1);
+      }
+    }
+
+  } // End of edgeblock variable loop.
+  return diff_flag;
+}
+
+template <typename INT>
+bool diff_faceblock(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, int step1, const TimeInterp &t2,
+                  int out_file_id, const INT *id_map, std::vector<MinMaxData> &mm_fb, double *vals)
+{
+  bool diff_flag = false;
+
+  if (out_file_id >= 0) {
+    SMART_ASSERT(vals != nullptr);
+  }
+
+  int name_length = max_string_length(file1.FB_Var_Names()) + 1;
+
+  if (out_file_id < 0 && !interFace.quiet_flag && !interFace.summary_flag &&
+      !interFace.fb_var_names.empty()) {
+    fmt::print("Face Block variables:\n");
+  }
+
+  for (unsigned f_idx = 0; f_idx < interFace.fb_var_names.size(); ++f_idx) {
+    const std::string &name  = (interFace.fb_var_names)[f_idx];
+    int                vidx1 = find_string(file1.FB_Var_Names(), name, interFace.nocase_var_names);
+    int                vidx2 = 0;
+    if (!interFace.summary_flag) {
+      vidx2 = find_string(file2.FB_Var_Names(), name, interFace.nocase_var_names);
+    }
+    if (vidx1 < 0 || vidx2 < 0) {
+      Error(fmt::format("Unable to find faceblock variable named '{}' on database.\n", name));
+      exit(1);
+    }
+
+    DiffData max_diff;
+    Norm     norm;
+
+    for (size_t b = 0; b < file1.Num_Face_Blocks(); ++b) {
+      Face_Block<INT> *fblock1 = file1.Get_Face_Block_by_Index(b);
+      SMART_ASSERT(fblock1 != nullptr);
+      if (fblock1->Size() == 0) {
+        continue;
+      }
+      if (!fblock1->is_valid_var(vidx1)) {
+        continue;
+      }
+
+      Face_Block<INT> *fblock2 = nullptr;
+      if (!interFace.summary_flag) {
+        if (interFace.by_name) {
+          fblock2 = file2.Get_Face_Block_by_Name(fblock1->Name());
+        }
+        else {
+          fblock2 = file2.Get_Face_Block_by_Id(fblock1->Id());
+        }
+        if (fblock2 == nullptr || !fblock2->is_valid_var(vidx2)) {
+          continue;
+        }
+      }
+
+      fblock1->Load_Results(step1, vidx1);
+      const double *vals1 = fblock1->Get_Results(vidx1);
+
+      if (vals1 == nullptr) {
+        Error(fmt::format("Could not find variable '{}' in faceblock {}, file 1.\n", name,
+                          fblock1->Id()));
+        diff_flag = true;
+        continue;
+      }
+
+      if (Invalid_Values(vals1, fblock1->Size())) {
+        Error(fmt::format("NaN found for faceblock variable '{}' in faceblock {}, file 1.\n", name,
+                          fblock1->Id()));
+        diff_flag = true;
+      }
+
+      double        v2    = 0;
+      const double *vals2 = nullptr;
+      if (!interFace.summary_flag) {
+        fblock2->Load_Results(t2.step1, t2.step2, t2.proportion, vidx2);
+        vals2 = fblock2->Get_Results(vidx2);
+
+        if (vals2 == nullptr) {
+          Error(fmt::format("Could not find variable '{}' in faceblock {}, file 2.\n", name,
+                            fblock2->Id()));
+          diff_flag = true;
+          continue;
+        }
+
+        if (Invalid_Values(vals2, fblock2->Size())) {
+          Error(fmt::format("NaN found for faceblock variable '{}' in faceblock {}, file 2.\n", name,
+                            fblock2->Id()));
+          diff_flag = true;
+        }
+      }
+
+      size_t fcount = fblock1->Size();
+      if (interFace.summary_flag || fblock2->Size() == fcount) {
+        for (size_t f = 0; f < fcount; ++f) {
+          size_t ind1 = fblock1->Face_Index(f);
+          size_t ind2 = 0;
+          if (out_file_id >= 0) {
+            vals[ind1] = 0.;
+          }
+          if (!interFace.summary_flag) {
+            ind2 = fblock2->Face_Index(f);
+            v2   = vals2[ind2];
+          }
+
+          if (interFace.summary_flag) {
+            mm_fb[f_idx].spec_min_max(vals1[ind1], step1, f, fblock1->Id());
+          }
+          else if (out_file_id >= 0) {
+            vals[ind1] = FileDiff(vals1[ind1], v2, interFace.output_type);
+          }
+          else if (interFace.show_all_diffs) {
+            double d = interFace.fb_var[f_idx].Delta(vals1[ind1], v2);
+            if (d > interFace.fb_var[f_idx].value) {
+              diff_flag = true;
+              buf       = fmt::format(
+                  "   {:<{}} {} diff: {:14.7e} ~ {:14.7e} ={:12.5e} (block {}, face {})", name,
+                  name_length, interFace.fb_var[f_idx].abrstr(), vals1[ind1], v2, d, fblock1->Id(),
+                  id_map[fblock1->Face_Index(f)]);
+              DIFF_OUT(buf);
+            }
+          }
+          else {
+            double d = interFace.fb_var[f_idx].Delta(vals1[ind1], v2);
+            max_diff.set_max(d, vals1[ind1], v2, f, fblock1->Id());
+          }
+          norm.add_value(vals1[ind1], v2);
+        }
+        if (out_file_id >= 0) {
+          ex_put_var(out_file_id, t2.step1, EX_FACE_BLOCK, f_idx + 1, fblock1->Id(), fblock1->Size(),
+                     vals);
+        }
+      }
+      else {
+        buf = fmt::format("   {:<{}}     diff: faceblock face counts differ for faceblock {}", name,
+                          name_length, fblock1->Id());
+        DIFF_OUT(buf);
+        diff_flag = true;
+      }
+
+      fblock1->Free_Results();
+      if (!interFace.summary_flag) {
+        fblock2->Free_Results();
+      }
+    } // End of faceblock loop.
+
+    if (!interFace.summary_flag && max_diff.diff > interFace.fb_var[f_idx].value) {
+      diff_flag = true;
+
+      if (interFace.doL1Norm && norm.diff(1) > 0.0) {
+        buf = fmt::format("   {:<{}} L1 norm of diff={:14.7e} ({:11.5e} ~ {:11.5e}) rel={:14.7e}",
+                          name, name_length, norm.diff(1), norm.left(1), norm.right(1),
+                          norm.relative(1));
+        DIFF_OUT(buf, fmt::color::green);
+      }
+      if (interFace.doL2Norm && norm.diff(2) > 0.0) {
+        buf = fmt::format("   {:<{}} L2 norm of diff={:14.7e} ({:11.5e} ~ {:11.5e}) rel={:14.7e}",
+                          name, name_length, norm.diff(2), norm.left(2), norm.right(2),
+                          norm.relative(2));
+        DIFF_OUT(buf, fmt::color::green);
+      }
+
+      if (!interFace.quiet_flag) {
+        Face_Block<INT> *fblock = file1.Get_Face_Block_by_Id(max_diff.blk);
+        buf = fmt::format("   {:<{}} {} diff: {:14.7e} ~ {:14.7e} ={:12.5e} (block {}, face {})",
+                          name, name_length, interFace.fb_var[f_idx].abrstr(), max_diff.val1,
+                          max_diff.val2, max_diff.diff, max_diff.blk,
+                          id_map[max_diff.id]);
+        DIFF_OUT(buf);
+      }
+      else {
+        Die_TS(step1);
+      }
+    }
+
+  } // End of faceblock variable loop.
+  return diff_flag;
+}
+
+template <typename INT>
 bool diff_element_attributes(ExoII_Read<INT> &file1, ExoII_Read<INT> &file2, INT * /*elmt_map*/,
                              const INT *id_map, Exo_Block<INT> ** /*blocks2*/)
 {
@@ -2329,6 +2738,7 @@ template <typename INT>
 void output_summary(ExoII_Read<INT> &file1, MinMaxData &mm_time, std::vector<MinMaxData> &mm_glob,
                     std::vector<MinMaxData> &mm_node, std::vector<MinMaxData> &mm_elmt,
                     std::vector<MinMaxData> &mm_ns, std::vector<MinMaxData> &mm_ss,
+                    std::vector<MinMaxData> &mm_eb, std::vector<MinMaxData> &mm_fb,
                     const INT *node_id_map, const INT *elem_id_map)
 {
   int name_length = 0;
@@ -2441,6 +2851,40 @@ void output_summary(ExoII_Read<INT> &file1, MinMaxData &mm_time, std::vector<Min
   }
   else {
     fmt::print("\n# No SIDESET VARIABLES\n");
+  }
+
+  n = interFace.eb_var_names.size();
+  if (n > 0) {
+    fmt::print("\nEDGE BLOCK VARIABLES relative 1.e-6 floor 0.0\n");
+    name_length = max_string_length(interFace.eb_var_names);
+    for (i = 0; i < n; ++i) {
+      fmt::print("\t{:<{}}  # min: {:15.8g} @ t{},b{},e{}\tmax: {:15.8g} @ t{},b{}"
+                 ",e{}\n",
+                 ((interFace.eb_var_names)[i]), name_length, mm_eb[i].min_val, 
+                 mm_eb[i].min_step, mm_eb[i].min_blk, elem_id_map[mm_eb[i].min_id],
+                 mm_eb[i].max_val, mm_eb[i].max_step, mm_eb[i].max_blk,
+                 elem_id_map[mm_eb[i].max_id]);
+    }
+  }
+  else {
+    fmt::print("\n# No EDGE BLOCK VARIABLES\n");
+  }
+
+  n = interFace.fb_var_names.size();
+  if (n > 0) {
+    fmt::print("\nFACE BLOCK VARIABLES relative 1.e-6 floor 0.0\n");
+    name_length = max_string_length(interFace.fb_var_names);
+    for (i = 0; i < n; ++i) {
+      fmt::print("\t{:<{}}  # min: {:15.8g} @ t{},b{},e{}\tmax: {:15.8g} @ t{},b{}"
+                 ",e{}\n",
+                 ((interFace.fb_var_names)[i]), name_length, mm_fb[i].min_val, 
+                 mm_fb[i].min_step, mm_fb[i].min_blk, elem_id_map[mm_fb[i].min_id],
+                 mm_fb[i].max_val, mm_fb[i].max_step, mm_fb[i].max_blk,
+                 elem_id_map[mm_fb[i].max_id]);
+    }
+  }
+  else {
+    fmt::print("\n# No FACE BLOCK VARIABLES\n");
   }
   fmt::print("\n");
 }

--- a/packages/seacas/applications/exodiff/face_block.C
+++ b/packages/seacas/applications/exodiff/face_block.C
@@ -1,0 +1,93 @@
+// Copyright(C) 1999-2020 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#include "ED_SystemInterface.h" // for SystemInterface, etc
+#include "exodusII.h"           // for ex_set, etc
+#include "iqsort.h"             // for index_qsort
+#include "face_block.h"
+#include "smart_assert.h" // for SMART_ASSERT
+#include <cstdlib>        // for exit
+#include <vector>         // for vector
+
+template <typename INT> Face_Block<INT>::Face_Block() : Exo_Entity() {}
+
+template <typename INT> Face_Block<INT>::Face_Block(int file_id, size_t id) : Exo_Entity(file_id, id)
+{
+  SMART_ASSERT((int)id != EX_INVALID_ID);
+}
+
+template <typename INT>
+Face_Block<INT>::Face_Block(int file_id, size_t id, size_t ne)
+    : Exo_Entity(file_id, id, ne)
+{
+  SMART_ASSERT(id > 0);
+}
+
+template <typename INT> Face_Block<INT>::~Face_Block()
+{
+  SMART_ASSERT(Check_State());
+
+  delete[] faceIndex;
+}
+
+template <typename INT> EXOTYPE Face_Block<INT>::exodus_type() const { return EX_FACE_BLOCK; }
+
+template <typename INT> void Face_Block<INT>::entity_load_params()
+{
+  int      num_attr;
+  ex_block block{};
+  block.id   = id_;
+  block.type = EX_FACE_BLOCK;
+  int err    = ex_get_block_param(fileId, &block);
+
+  numEntity          = block.num_entry;
+  num_faces_per_elmt = block.num_faces_per_entry;
+  num_attr           = block.num_attribute;
+  elmt_type          = block.topology;
+
+  if (num_faces_per_elmt < 0 || num_attr < 0) {
+    Error(fmt::format("Exo_Block<INT>::Load_Block_Params(): Data appears corrupt for block {}!\n"
+                      "\tnum elmts          = {:n}\n"
+                      "\tnum faces per elmt = {}\n"
+                      "\tnum attributes     = {}\n"
+                      " ... Aborting...\n",
+                      numEntity, num_faces_per_elmt, num_attr));
+    exit(1);
+  }
+}
+
+template <typename INT> void Face_Block<INT>::load_faces(const INT *elmt_map) const
+{
+  int err = 0;
+  if ((faceIndex == nullptr) && numEntity > 0) {
+    faceIndex = new INT[numEntity];
+    SMART_ASSERT(faceIndex != nullptr);
+
+    for (size_t i = 0; i < numEntity; i++) {
+      faceIndex[i] = i;
+    }
+    SMART_ASSERT(Check_State());
+  }
+}
+
+template <typename INT> size_t Face_Block<INT>::Face_Index(size_t position) const
+{
+  load_faces();
+  SMART_ASSERT(position < numEntity);
+  return faceIndex[position];
+}
+
+template <typename INT> int Face_Block<INT>::Check_State() const
+{
+  SMART_ASSERT(id_ >= EX_INVALID_ID);
+  SMART_ASSERT(!(id_ == EX_INVALID_ID && numEntity > 0));
+  SMART_ASSERT(!(id_ == EX_INVALID_ID && faceIndex));
+
+  return 1;
+}
+
+template class Face_Block<int>;
+template class Face_Block<int64_t>;

--- a/packages/seacas/applications/exodiff/face_block.h
+++ b/packages/seacas/applications/exodiff/face_block.h
@@ -1,0 +1,46 @@
+// Copyright(C) 1999-2020 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#ifndef FACE_BLOCK_H
+#define FACE_BLOCK_H
+
+#include "exo_entity.h"
+#include <iostream>
+
+template <typename INT> class ExoII_Read;
+
+template <typename INT> class Face_Block : public Exo_Entity
+{
+public:
+  Face_Block();
+  Face_Block(int file_id, size_t id);
+  Face_Block(int file_id, size_t id, size_t ne);
+  ~Face_Block() override;
+
+  size_t              Face_Index(size_t position) const;
+
+  int    Check_State() const;
+
+private:
+  Face_Block(const Face_Block &);                  // Not written.
+  const Face_Block &operator=(const Face_Block &); // Not written.
+
+  void load_faces(const INT *elmt_map = nullptr) const;
+  void entity_load_params() override;
+
+  EXOTYPE     exodus_type() const override;
+  const char *label() const override { return "Faceblock"; }
+  const char *short_label() const override { return "faceblock"; }
+
+  mutable INT *   faceIndex{nullptr};
+
+  std::string elmt_type;
+  int         num_faces_per_elmt;
+
+  friend class ExoII_Read<INT>;
+};
+
+#endif

--- a/packages/seacas/applications/exodiff/test_generate_exo_files.c
+++ b/packages/seacas/applications/exodiff/test_generate_exo_files.c
@@ -1,0 +1,1758 @@
+/*
+ * Copyright(C) 1999-2020 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ *
+ * See packages/seacas/LICENSE for details
+ */
+#include "exodusII.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define EX_TEST_GOLD_FILENAME    "edge-face-gold.exo"
+#define EX_TEST_NO_DIFF_FILENAME "edge-face-no-diff.exo"
+#define EX_TEST_EDGE_DIFF_FILENAME    "edge-diff.exo"
+#define EX_TEST_FACE_DIFF_FILENAME    "face-diff.exo"
+
+/* ======== Coordinates and connectivity ========= */
+double coordsX[] = {0., 0., 0., 0., 3., 3., 3., 3., -3., -3., -3., -3.};
+
+double coordsY[] = {-1., 1., 1., -1., -3., 3., 3., -3., -3., 3., 3., -3.};
+
+double coordsZ[] = {-1., -1., 1., 1., -3., -3., 3., 3., -3., -3., 3., 3.};
+
+const char *coordsNames[] = {"X", "Y", "Z"};
+
+int conn1[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4};
+
+int conn2[] = {1, 2, 3, 5};
+
+int econn1[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1, 2, 3, 4, 17, 18, 19, 20};
+
+int fconn1[] = {4, 5, 7, 6, 3, 2, 8, 9, 11, 10, 1, 3};
+
+int ebconn1[] = {1, 2, 2, 3, 3, 4,  4,  1,  5,  6,  6,  7, 7, 8, 8,  5, 1,  5, 2,  6,
+                 4, 8, 3, 7, 9, 10, 10, 11, 11, 12, 12, 9, 9, 1, 10, 2, 12, 4, 11, 3};
+
+int fbconn1[] = {12, 11, 10, 9, 5, 6, 7, 8};
+
+int fbconn2[] = {1, 2, 3, 4};
+
+int fbconn3[] = {1, 5, 6, 2,  3,  7, 8, 4,  2,  6, 7, 3,  4,  8, 5, 1,
+                 9, 1, 2, 10, 11, 3, 4, 12, 10, 2, 3, 11, 12, 4, 1, 9};
+
+int nmap1[] = {12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+
+int edmap1[] = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
+
+int famap1[] = {2, 1, 4, 3, 6, 5, 7, 8, 9, 10, 11};
+
+int emap1[] = {1, 2};
+
+const char *eblk_names[]  = {"Eli_WALLACH", "Angelo_NOVI"};
+const char *edblk_names[] = {"Aldo_GIUFFRE"};
+const char *fablk_names[] = {"Livio_LORENZON", "Claudio_SCARCHILLI", "John_BARTHA"};
+
+const char *nmap_names[]  = {"Luigi_PISTILLI"};
+const char *edmap_names[] = {"Antonio_CASALE"};
+const char *famap_names[] = {"Sandro_SCARCHILLI"};
+const char *emap_names[]  = {"Benito_STEFANELLI"};
+
+/* ======== Sets ========= */
+int nset_nodes[] = {5, 6, 9};
+
+int eset_edges[] = {1, 2, 4, 15, 19, 20};
+
+int eset_orient[] = {+1, +1, +1, +1, +1, -1};
+
+double eset_df[] = {2., 2., 0.5, 0.5, 1., 1.};
+
+int fset_faces[] = {3, 9};
+
+int fset_orient[] = {+1, -1};
+
+int sset_elems[] = {1, 1, 1, 2, 2};
+
+int sset_sides[] = {1, 3, 5, 2, 4};
+
+int elset_elems[] = {1, 2};
+
+const char *elset_names[] = {"Clint_EASTWOOD", "Lee_VAN_CLEEF"};
+
+const char *nset_names[] = {"Ennio_MORRICONE"};
+const char *eset_names[] = {"Rada_RASSIMOV"};
+const char *fset_names[] = {"Enzo_PETITO"};
+const char *sset_names[] = {"Luciano_VINCENZONI"};
+
+/* ======== Attributes ========= */
+const char *edge_attr_names1[] = {"Sergio_LEONE"};
+
+const char *face_attr_names1[] = {"GOOD"};
+const char *face_attr_names2[] = {"BAD"};
+const char *face_attr_names3[] = {"UGLY"};
+
+const char *elem_attr_names1[] = {"SPAGHETTI", "WESTERN"};
+
+double edge_attr_values1[] = {1.,  2.,  3.,  5.,  7.,  11., 13., 17., 19., 23.,
+                              29., 31., 37., 41., 43., 47., 53., 59., 61., 67.};
+
+double face_attr_values1[] = {71., 73.};
+
+double face_attr_values2[] = {79.};
+
+double face_attr_values3[] = {83., 89., 97., 101., 103., 107., 109., 113.};
+
+double elem_attr_values1[] = {127., 101., 137., 139.};
+
+/* ======== Results variables ========= */
+/*           (2 time steps) */
+
+double vals_glo_var[2][2] = {{36., 37.}, {42., 43.}};
+
+double vals_nod_var[2][12] = {{0.1, 0.8, 0.0, 0.4, 0.3, 0.9, 0.8, 0.5, 0.3, 0.7, 0.4, 0.6},
+                              {0.7, 0.5, 0.3, 0.5, 0.2, 0.7, 0.9, 0.8, 0.0, 0.2, 0.3, 0.5}};
+
+double vals_edge_var1eb1[2][20] = {
+    {20., 19., 18., 17., 16., 15., 14., 13., 12., 11., 10., 9., 8., 7., 6., 5., 4., 3., 2., 1.},
+    {21., 20., 19., 18., 17., 16., 15., 14., 13., 12., 11., 10., 9., 8., 7., 6., 5., 4., 3., 2.}};
+
+double diff_vals_edge_var1eb1[2][20] = {
+    {21., 20., 19., 18., 17., 16., 15., 14., 13., 12., 11., 10., 9., 8., 7., 6., 5., 4., 3., 2.},
+    {20., 19., 18., 17., 16., 15., 14., 13., 12., 11., 10., 9., 8., 7., 6., 5., 4., 3., 2., 1.}};
+
+double vals_edge_var2eb1[2][20] = {
+    {1., 1., 0., 0., 1., 1., 2., 0., 2., 0., 1., 1., 1., 1., 0., 0., 2., 2., 2., 2.},
+    {1., 1., 0., 0., 1., 1., 2., 0., 2., 0., 1., 1., 1., 1., 0., 0., 2., 2., 2., 2.}};
+
+double vals_face_var1fb1[2][2] = {{0, 1}, {2, 0}};
+
+double diff_vals_face_var1fb1[2][2] = {{2, 0}, {0, 1}};
+
+double vals_face_var1fb3[2][8] = {{1, 0, 2, 0, 3, 0, 4, 0}, {0, 1, 0, 2, 0, 3, 0, 4}};
+
+double vals_elem_var1eb1[2][2] = {{8, 8}, {0, -8}};
+
+double vals_fset_var1fs1[2][2] = {{1., 3.}, {9., 27.}};
+
+#define EXCHECK(funcall, errmsg)                                                                   \
+  if ((funcall) < 0) {                                                                             \
+    fprintf(stderr, errmsg);                                                                       \
+    free(varParams.edge_var_tab);                                                                  \
+    free(varParams.face_var_tab);                                                                  \
+    free(varParams.elem_var_tab);                                                                  \
+    free(varParams.fset_var_tab);                                                                  \
+    return 1;                                                                                      \
+  }
+
+int ex_have_arg(int argc, char *argv[], const char *aname)
+{
+  int i;
+  for (i = 0; i < argc; ++i) {
+    if (!strcmp(argv[i], aname)) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int create_gold_file(int argc, char *argv[])
+{
+  int exoid;
+  int appWordSize  = 8;
+  int diskWordSize = 8;
+  /*  int concatBlocks = ex_have_arg( argc, argv, "-pcab" ); */
+  int    concatSets   = ex_have_arg(argc, argv, "-pcset");
+  int    concatResult = ex_have_arg(argc, argv, "-pvpax");
+  double t;
+
+  ex_init_params modelParams = {
+      "CreateEdgeFace Test", /* title */
+      3,                     /* num_dim */
+      12,                    /* num_nodes */
+      20,                    /* num_edge */
+      1,                     /* num_edge_blk */
+      11,                    /* num_face */
+      3,                     /* num_face_blk */
+      3,                     /* num_elem */
+      2,                     /* num_elem_blk */
+      1,                     /* num_node_sets */
+      1,                     /* num_edge_sets */
+      1,                     /* num_face_sets */
+      1,                     /* num_side_sets */
+      2,                     /* num_elem_sets */
+      1,                     /* num_node_map */
+      1,                     /* num_edge_map */
+      1,                     /* num_face_map */
+      1,                     /* num_elem_map */
+  };
+
+  ex_block edgeBlocks[1];
+  ex_block faceBlocks[3];
+  ex_block elemBlocks[2];
+
+  ex_var_params varParams;
+
+  ex_opts(EX_VERBOSE | EX_ABORT);
+
+  exoid = ex_create(EX_TEST_GOLD_FILENAME, EX_CLOBBER, &appWordSize, &diskWordSize);
+  if (exoid <= 0) {
+    fprintf(stderr, "Unable to open \"%s\" for writing.\n", EX_TEST_GOLD_FILENAME);
+    return 1;
+  }
+
+  edgeBlocks[0].type                = EX_EDGE_BLOCK;
+  edgeBlocks[0].id                  = 100;
+  edgeBlocks[0].num_entry           = 20;
+  edgeBlocks[0].num_nodes_per_entry = 2;
+  edgeBlocks[0].num_attribute       = 1;
+  ex_copy_string(edgeBlocks[0].topology, "EDGE2", MAX_STR_LENGTH + 1);
+
+  faceBlocks[0].type                = EX_FACE_BLOCK;
+  faceBlocks[0].id                  = 500;
+  faceBlocks[0].num_entry           = 2;
+  faceBlocks[0].num_nodes_per_entry = 4;
+  faceBlocks[0].num_attribute       = 1;
+  ex_copy_string(faceBlocks[0].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  faceBlocks[1].type                = EX_FACE_BLOCK;
+  faceBlocks[1].id                  = 600;
+  faceBlocks[1].num_entry           = 1;
+  faceBlocks[1].num_nodes_per_entry = 4;
+  faceBlocks[1].num_attribute       = 1;
+  ex_copy_string(faceBlocks[1].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  faceBlocks[2].type                = EX_FACE_BLOCK;
+  faceBlocks[2].id                  = 700;
+  faceBlocks[2].num_entry           = 8;
+  faceBlocks[2].num_nodes_per_entry = 4;
+  faceBlocks[2].num_attribute       = 1;
+  ex_copy_string(faceBlocks[2].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  elemBlocks[0].type                = EX_ELEM_BLOCK;
+  elemBlocks[0].id                  = 200;
+  elemBlocks[0].num_entry           = 2;
+  elemBlocks[0].num_nodes_per_entry = 8;
+  elemBlocks[0].num_edges_per_entry = 12;
+  elemBlocks[0].num_faces_per_entry = 6;
+  elemBlocks[0].num_attribute       = 2;
+  ex_copy_string(elemBlocks[0].topology, "HEX8", MAX_STR_LENGTH + 1);
+
+  elemBlocks[1].type                = EX_ELEM_BLOCK;
+  elemBlocks[1].id                  = 201;
+  elemBlocks[1].num_entry           = 1;
+  elemBlocks[1].num_nodes_per_entry = 4;
+  elemBlocks[1].num_edges_per_entry = 0;
+  elemBlocks[1].num_faces_per_entry = 0;
+  elemBlocks[1].num_attribute       = 0;
+  ex_copy_string(elemBlocks[1].topology, "TET4", MAX_STR_LENGTH + 1);
+
+  varParams.edge_var_tab  = (int *)malloc(2 * sizeof(int));
+  varParams.face_var_tab  = (int *)malloc(3 * sizeof(int));
+  varParams.elem_var_tab  = (int *)malloc(2 * sizeof(int));
+  varParams.nset_var_tab  = (int *)0;
+  varParams.eset_var_tab  = (int *)0;
+  varParams.fset_var_tab  = (int *)malloc(1 * sizeof(int));
+  varParams.sset_var_tab  = (int *)0;
+  varParams.elset_var_tab = (int *)0;
+
+  varParams.num_glob        = 2;
+  varParams.num_node        = 1;
+  varParams.num_edge        = 2;
+  varParams.edge_var_tab[0] = 1;
+  varParams.edge_var_tab[1] = 1;
+  varParams.num_face        = 1;
+  varParams.face_var_tab[0] = 1;
+  varParams.face_var_tab[1] = 1;
+  varParams.face_var_tab[2] = 1;
+  varParams.num_elem        = 1;
+  varParams.elem_var_tab[0] = 1;
+  varParams.elem_var_tab[1] = 0;
+  varParams.num_nset        = 0;
+  varParams.num_eset        = 0;
+  ;
+  varParams.num_fset        = 1;
+  varParams.fset_var_tab[0] = 1;
+  varParams.num_sset        = 0;
+  varParams.num_elset       = 0;
+
+  EXCHECK(ex_put_init_ext(exoid, &modelParams), "Unable to initialize database.\n");
+
+  {
+    int blk;
+    for (blk = 0; blk < modelParams.num_edge_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, edgeBlocks[blk]), "Unable to write edge block");
+    }
+    for (blk = 0; blk < modelParams.num_face_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, faceBlocks[blk]), "Unable to write face block");
+    }
+    for (blk = 0; blk < modelParams.num_elem_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, elemBlocks[blk]), "Unable to write elem block");
+    }
+  }
+
+  EXCHECK(ex_put_coord(exoid, (void *)coordsX, (void *)coordsY, (void *)coordsZ),
+          "Unable to write coordinates.\n");
+
+  EXCHECK(ex_put_coord_names(exoid, (char **)coordsNames), "Unable to write coordinate names.\n");
+
+  /*                  =============== Connectivity  ================== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, ebconn1, 0, 0),
+          "Unable to write edge block connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[0].id, fbconn1, 0, 0),
+          "Unable to write face block 1 connectivity.\n");
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[1].id, fbconn2, 0, 0),
+          "Unable to write face block 2 connectivity.\n");
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[2].id, fbconn3, 0, 0),
+          "Unable to write face block 3 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, conn1, econn1, fconn1),
+          "Unable to write elem block 1 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_ELEM_BLOCK, elemBlocks[1].id, conn2, 0, 0),
+          "Unable to write elem block 2 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_EDGE_BLOCK, (char **)edblk_names),
+          "Unable to write edge block names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_BLOCK, (char **)fablk_names),
+          "Unable to write face block names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_BLOCK, (char **)eblk_names),
+          "Unable to write element block names.\n");
+
+  /*                  =============== Number Maps   ================== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_num_map(exoid, EX_NODE_MAP, 300, nmap1), "Unable to write node map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_EDGE_MAP, 800, edmap1), "Unable to write edge map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_FACE_MAP, 900, famap1), "Unable to write face map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_ELEM_MAP, 400, emap1), "Unable to write element map.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_NODE_MAP, (char **)nmap_names),
+          "Unable to write node map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_EDGE_MAP, (char **)edmap_names),
+          "Unable to write edge map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_MAP, (char **)famap_names),
+          "Unable to write face map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_MAP, (char **)emap_names),
+          "Unable to write element map names.\n");
+
+  /*                 =============== Attribute names ================ */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, (char **)edge_attr_names1),
+          "Unable to write edge block 1 attribute names.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[0].id, (char **)face_attr_names1),
+          "Unable to write face block 1 attribute names.\n");
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[1].id, (char **)face_attr_names2),
+          "Unable to write face block 1 attribute names.\n");
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[2].id, (char **)face_attr_names3),
+          "Unable to write face block 1 attribute names.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, (char **)elem_attr_names1),
+          "Unable to write elem block 1 attribute names.\n");
+
+  /*                  =============== Attribute values =============== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, edge_attr_values1),
+          "Unable to write edge block 1 attribute values.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[0].id, face_attr_values1),
+          "Unable to write face block 1 attribute values.\n");
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[1].id, face_attr_values2),
+          "Unable to write face block 1 attribute values.\n");
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[2].id, face_attr_values3),
+          "Unable to write face block 1 attribute values.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, elem_attr_values1),
+          "Unable to write elem block 1 attribute values.\n");
+
+  /*                  =============== Set parameters ================= */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_NODE_SET, (char **)nset_names),
+          "Unable to write node set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_EDGE_SET, (char **)eset_names),
+          "Unable to write edge set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_SET, (char **)fset_names),
+          "Unable to write face set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_SIDE_SET, (char **)sset_names),
+          "Unable to write side set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_SET, (char **)elset_names),
+          "Unable to write element set names.\n");
+
+  {
+    ex_set allSets[1 + 1 + 1 + 1 + 2];
+
+    ex_set *nodeSets = &allSets[0];
+    ex_set *edgeSets = &allSets[1];
+    ex_set *faceSets = &allSets[2];
+    ex_set *sideSets = &allSets[3];
+    ex_set *elemSets = &allSets[4];
+
+    nodeSets[0].type                     = EX_NODE_SET;
+    nodeSets[0].id                       = 1000;
+    nodeSets[0].num_entry                = 3;
+    nodeSets[0].num_distribution_factor  = 0;
+    nodeSets[0].entry_list               = nset_nodes;
+    nodeSets[0].extra_list               = NULL;
+    nodeSets[0].distribution_factor_list = NULL;
+
+    edgeSets[0].type                     = EX_EDGE_SET;
+    edgeSets[0].id                       = 1200;
+    edgeSets[0].num_entry                = 6;
+    edgeSets[0].num_distribution_factor  = 6;
+    edgeSets[0].entry_list               = eset_edges;
+    edgeSets[0].extra_list               = eset_orient;
+    edgeSets[0].distribution_factor_list = eset_df;
+
+    faceSets[0].type                     = EX_FACE_SET;
+    faceSets[0].id                       = 1400;
+    faceSets[0].num_entry                = 2;
+    faceSets[0].num_distribution_factor  = 0;
+    faceSets[0].entry_list               = fset_faces;
+    faceSets[0].extra_list               = fset_orient;
+    faceSets[0].distribution_factor_list = NULL;
+
+    sideSets[0].type                     = EX_SIDE_SET;
+    sideSets[0].id                       = 1400;
+    sideSets[0].num_entry                = 5;
+    sideSets[0].num_distribution_factor  = 0;
+    sideSets[0].entry_list               = sset_elems;
+    sideSets[0].extra_list               = sset_sides;
+    sideSets[0].distribution_factor_list = NULL;
+
+    elemSets[0].type                     = EX_ELEM_SET;
+    elemSets[0].id                       = 1800;
+    elemSets[0].num_entry                = 1;
+    elemSets[0].num_distribution_factor  = 0;
+    elemSets[0].entry_list               = &elset_elems[0];
+    elemSets[0].extra_list               = NULL;
+    elemSets[0].distribution_factor_list = NULL;
+
+    elemSets[1].type                     = EX_ELEM_SET;
+    elemSets[1].id                       = 1900;
+    elemSets[1].num_entry                = 1;
+    elemSets[1].num_distribution_factor  = 0;
+    elemSets[1].entry_list               = &elset_elems[1];
+    elemSets[1].extra_list               = NULL;
+    elemSets[1].distribution_factor_list = NULL;
+
+    if (concatSets) {
+      EXCHECK(ex_put_sets(exoid, 1 + 2 + 1 + 1 + 1, allSets),
+              "Unable to output concatenated sets.\n");
+    }
+    else {
+      EXCHECK(ex_put_sets(exoid, 1, nodeSets), "Unable to write node sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, edgeSets), "Unable to write edge sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, faceSets), "Unable to write face sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, sideSets), "Unable to write side sets.\n");
+      EXCHECK(ex_put_sets(exoid, 2, elemSets), "Unable to write element sets.\n");
+    }
+  }
+
+  /*                  =============== Result variable params ========= */
+  /* *** NEW API *** */
+  if (concatResult) {
+    EXCHECK(ex_put_all_var_param_ext(exoid, &varParams),
+            "Unable to write result variable parameter information.\n");
+  }
+  else {
+    EXCHECK(ex_put_variable_param(exoid, EX_GLOBAL, 2),
+            "Unable to write global result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_NODAL, 1),
+            "Unable to write nodal result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_ELEM_BLOCK, 1),
+            "Unable to write element result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_EDGE_BLOCK, 2),
+            "Unable to write edge result variable parameters.\n");
+//    EXCHECK(ex_put_variable_param(exoid, EX_FACE_BLOCK, 2),
+//            "Unable to write face result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_FACE_BLOCK, 1),
+            "Unable to write face result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_FACE_SET, 1),
+            "Unable to write faceset result variable parameters.\n");
+  }
+
+  /*                  =============== Result variable names ========== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_variable_name(exoid, EX_GLOBAL, 1, "CALIBER"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_GLOBAL, 2, "GUNPOWDER"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_NODAL, 1, "RHO"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_EDGE_BLOCK, 1, "GAMMA1"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_EDGE_BLOCK, 2, "GAMMA2"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_FACE_BLOCK, 1, "PHI"), "Unable to write variable name.\n");
+//  EXCHECK(ex_put_variable_name(exoid, EX_FACE_BLOCK, 2, "PHI"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_ELEM_BLOCK, 1, "EPSTRN"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_FACE_SET, 1, "PHI0"), "Unable to write variable name.\n");
+
+  /*                  =============== Result variable values ========= */
+  t = 1.;
+  /* *** NEW API *** */
+  EXCHECK(ex_put_time(exoid, 1, &t), "Unable to write time value.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_GLOBAL, 1, 0 /*N/A*/, 2, vals_glo_var[0]),
+          "Unable to write global var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_EDGE_BLOCK, 1, 100, 20, vals_edge_var1eb1[0]),
+          "Unable to write edge block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_EDGE_BLOCK, 2, 100, 20, vals_edge_var2eb1[0]),
+          "Unable to write edge block 1 var 2.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 1, 500, 2, vals_face_var1fb1[0]),
+          "Unable to write face block 1 var 1.\n");
+//  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 2, 700, 8, vals_face_var1fb3[0]),
+//          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 1, 700, 8, vals_face_var1fb3[0]),
+          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_ELEM_BLOCK, 1, 200, 2, vals_elem_var1eb1[0]),
+          "Unable to write elem block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_SET, 1, 1400, 2, vals_fset_var1fs1[0]),
+          "Unable to write face set 1 var 1.\n");
+
+  t = 2.;
+  EXCHECK(ex_put_time(exoid, 2, &t), "Unable to write time value.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_GLOBAL, 1, 0 /*N/A*/, 2, vals_glo_var[1]),
+          "Unable to write global var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_EDGE_BLOCK, 1, 100, 20, vals_edge_var1eb1[1]),
+          "Unable to write edge block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_EDGE_BLOCK, 2, 100, 20, vals_edge_var2eb1[1]),
+          "Unable to write edge block 1 var 2.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 1, 500, 2, vals_face_var1fb1[1]),
+          "Unable to write face block 1 var 1.\n");
+//  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 2, 700, 8, vals_face_var1fb3[1]),
+//          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 1, 700, 8, vals_face_var1fb3[1]),
+          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_ELEM_BLOCK, 1, 200, 2, vals_elem_var1eb1[1]),
+          "Unable to write elem block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_SET, 1, 1400, 2, vals_fset_var1fs1[1]),
+          "Unable to write face set 1 var 1.\n");
+
+  EXCHECK(ex_put_var(exoid, 1, EX_NODAL, 1, 1, 12, vals_nod_var[0]),
+          "Unable to write nodal var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_NODAL, 1, 1, 12, vals_nod_var[1]),
+          "Unable to write nodal var 1.\n");
+
+  EXCHECK(ex_close(exoid), "Unable to close database.\n");
+
+  free(varParams.edge_var_tab);
+  free(varParams.face_var_tab);
+  free(varParams.elem_var_tab);
+  free(varParams.fset_var_tab);
+  return 0;
+}
+
+int create_no_diff_file(int argc, char *argv[])
+{
+  int exoid;
+  int appWordSize  = 8;
+  int diskWordSize = 8;
+  /*  int concatBlocks = ex_have_arg( argc, argv, "-pcab" ); */
+  int    concatSets   = ex_have_arg(argc, argv, "-pcset");
+  int    concatResult = ex_have_arg(argc, argv, "-pvpax");
+  double t;
+
+  ex_init_params modelParams = {
+      "CreateEdgeFace Test", /* title */
+      3,                     /* num_dim */
+      12,                    /* num_nodes */
+      20,                    /* num_edge */
+      1,                     /* num_edge_blk */
+      11,                    /* num_face */
+      3,                     /* num_face_blk */
+      3,                     /* num_elem */
+      2,                     /* num_elem_blk */
+      1,                     /* num_node_sets */
+      1,                     /* num_edge_sets */
+      1,                     /* num_face_sets */
+      1,                     /* num_side_sets */
+      2,                     /* num_elem_sets */
+      1,                     /* num_node_map */
+      1,                     /* num_edge_map */
+      1,                     /* num_face_map */
+      1,                     /* num_elem_map */
+  };
+
+  ex_block edgeBlocks[1];
+  ex_block faceBlocks[3];
+  ex_block elemBlocks[2];
+
+  ex_var_params varParams;
+
+  ex_opts(EX_VERBOSE | EX_ABORT);
+
+  exoid = ex_create(EX_TEST_NO_DIFF_FILENAME, EX_CLOBBER, &appWordSize, &diskWordSize);
+  if (exoid <= 0) {
+    fprintf(stderr, "Unable to open \"%s\" for writing.\n", EX_TEST_NO_DIFF_FILENAME);
+    return 1;
+  }
+
+  edgeBlocks[0].type                = EX_EDGE_BLOCK;
+  edgeBlocks[0].id                  = 100;
+  edgeBlocks[0].num_entry           = 20;
+  edgeBlocks[0].num_nodes_per_entry = 2;
+  edgeBlocks[0].num_attribute       = 1;
+  ex_copy_string(edgeBlocks[0].topology, "EDGE2", MAX_STR_LENGTH + 1);
+
+  faceBlocks[0].type                = EX_FACE_BLOCK;
+  faceBlocks[0].id                  = 500;
+  faceBlocks[0].num_entry           = 2;
+  faceBlocks[0].num_nodes_per_entry = 4;
+  faceBlocks[0].num_attribute       = 1;
+  ex_copy_string(faceBlocks[0].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  faceBlocks[1].type                = EX_FACE_BLOCK;
+  faceBlocks[1].id                  = 600;
+  faceBlocks[1].num_entry           = 1;
+  faceBlocks[1].num_nodes_per_entry = 4;
+  faceBlocks[1].num_attribute       = 1;
+  ex_copy_string(faceBlocks[1].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  faceBlocks[2].type                = EX_FACE_BLOCK;
+  faceBlocks[2].id                  = 700;
+  faceBlocks[2].num_entry           = 8;
+  faceBlocks[2].num_nodes_per_entry = 4;
+  faceBlocks[2].num_attribute       = 1;
+  ex_copy_string(faceBlocks[2].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  elemBlocks[0].type                = EX_ELEM_BLOCK;
+  elemBlocks[0].id                  = 200;
+  elemBlocks[0].num_entry           = 2;
+  elemBlocks[0].num_nodes_per_entry = 8;
+  elemBlocks[0].num_edges_per_entry = 12;
+  elemBlocks[0].num_faces_per_entry = 6;
+  elemBlocks[0].num_attribute       = 2;
+  ex_copy_string(elemBlocks[0].topology, "HEX8", MAX_STR_LENGTH + 1);
+
+  elemBlocks[1].type                = EX_ELEM_BLOCK;
+  elemBlocks[1].id                  = 201;
+  elemBlocks[1].num_entry           = 1;
+  elemBlocks[1].num_nodes_per_entry = 4;
+  elemBlocks[1].num_edges_per_entry = 0;
+  elemBlocks[1].num_faces_per_entry = 0;
+  elemBlocks[1].num_attribute       = 0;
+  ex_copy_string(elemBlocks[1].topology, "TET4", MAX_STR_LENGTH + 1);
+
+  varParams.edge_var_tab  = (int *)malloc(2 * sizeof(int));
+  varParams.face_var_tab  = (int *)malloc(3 * sizeof(int));
+  varParams.elem_var_tab  = (int *)malloc(2 * sizeof(int));
+  varParams.nset_var_tab  = (int *)0;
+  varParams.eset_var_tab  = (int *)0;
+  varParams.fset_var_tab  = (int *)malloc(1 * sizeof(int));
+  varParams.sset_var_tab  = (int *)0;
+  varParams.elset_var_tab = (int *)0;
+
+  varParams.num_glob        = 2;
+  varParams.num_node        = 1;
+  varParams.num_edge        = 2;
+  varParams.edge_var_tab[0] = 1;
+  varParams.edge_var_tab[1] = 1;
+  varParams.num_face        = 1;
+  varParams.face_var_tab[0] = 1;
+  varParams.face_var_tab[1] = 1;
+  varParams.face_var_tab[2] = 1;
+  varParams.num_elem        = 1;
+  varParams.elem_var_tab[0] = 1;
+  varParams.elem_var_tab[1] = 0;
+  varParams.num_nset        = 0;
+  varParams.num_eset        = 0;
+  ;
+  varParams.num_fset        = 1;
+  varParams.fset_var_tab[0] = 1;
+  varParams.num_sset        = 0;
+  varParams.num_elset       = 0;
+
+  EXCHECK(ex_put_init_ext(exoid, &modelParams), "Unable to initialize database.\n");
+
+  {
+    int blk;
+    for (blk = 0; blk < modelParams.num_edge_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, edgeBlocks[blk]), "Unable to write edge block");
+    }
+    for (blk = 0; blk < modelParams.num_face_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, faceBlocks[blk]), "Unable to write face block");
+    }
+    for (blk = 0; blk < modelParams.num_elem_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, elemBlocks[blk]), "Unable to write elem block");
+    }
+  }
+
+  EXCHECK(ex_put_coord(exoid, (void *)coordsX, (void *)coordsY, (void *)coordsZ),
+          "Unable to write coordinates.\n");
+
+  EXCHECK(ex_put_coord_names(exoid, (char **)coordsNames), "Unable to write coordinate names.\n");
+
+  /*                  =============== Connectivity  ================== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, ebconn1, 0, 0),
+          "Unable to write edge block connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[0].id, fbconn1, 0, 0),
+          "Unable to write face block 1 connectivity.\n");
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[1].id, fbconn2, 0, 0),
+          "Unable to write face block 2 connectivity.\n");
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[2].id, fbconn3, 0, 0),
+          "Unable to write face block 3 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, conn1, econn1, fconn1),
+          "Unable to write elem block 1 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_ELEM_BLOCK, elemBlocks[1].id, conn2, 0, 0),
+          "Unable to write elem block 2 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_EDGE_BLOCK, (char **)edblk_names),
+          "Unable to write edge block names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_BLOCK, (char **)fablk_names),
+          "Unable to write face block names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_BLOCK, (char **)eblk_names),
+          "Unable to write element block names.\n");
+
+  /*                  =============== Number Maps   ================== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_num_map(exoid, EX_NODE_MAP, 300, nmap1), "Unable to write node map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_EDGE_MAP, 800, edmap1), "Unable to write edge map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_FACE_MAP, 900, famap1), "Unable to write face map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_ELEM_MAP, 400, emap1), "Unable to write element map.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_NODE_MAP, (char **)nmap_names),
+          "Unable to write node map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_EDGE_MAP, (char **)edmap_names),
+          "Unable to write edge map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_MAP, (char **)famap_names),
+          "Unable to write face map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_MAP, (char **)emap_names),
+          "Unable to write element map names.\n");
+
+  /*                 =============== Attribute names ================ */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, (char **)edge_attr_names1),
+          "Unable to write edge block 1 attribute names.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[0].id, (char **)face_attr_names1),
+          "Unable to write face block 1 attribute names.\n");
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[1].id, (char **)face_attr_names2),
+          "Unable to write face block 1 attribute names.\n");
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[2].id, (char **)face_attr_names3),
+          "Unable to write face block 1 attribute names.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, (char **)elem_attr_names1),
+          "Unable to write elem block 1 attribute names.\n");
+
+  /*                  =============== Attribute values =============== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, edge_attr_values1),
+          "Unable to write edge block 1 attribute values.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[0].id, face_attr_values1),
+          "Unable to write face block 1 attribute values.\n");
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[1].id, face_attr_values2),
+          "Unable to write face block 1 attribute values.\n");
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[2].id, face_attr_values3),
+          "Unable to write face block 1 attribute values.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, elem_attr_values1),
+          "Unable to write elem block 1 attribute values.\n");
+
+  /*                  =============== Set parameters ================= */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_NODE_SET, (char **)nset_names),
+          "Unable to write node set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_EDGE_SET, (char **)eset_names),
+          "Unable to write edge set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_SET, (char **)fset_names),
+          "Unable to write face set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_SIDE_SET, (char **)sset_names),
+          "Unable to write side set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_SET, (char **)elset_names),
+          "Unable to write element set names.\n");
+
+  {
+    ex_set allSets[1 + 1 + 1 + 1 + 2];
+
+    ex_set *nodeSets = &allSets[0];
+    ex_set *edgeSets = &allSets[1];
+    ex_set *faceSets = &allSets[2];
+    ex_set *sideSets = &allSets[3];
+    ex_set *elemSets = &allSets[4];
+
+    nodeSets[0].type                     = EX_NODE_SET;
+    nodeSets[0].id                       = 1000;
+    nodeSets[0].num_entry                = 3;
+    nodeSets[0].num_distribution_factor  = 0;
+    nodeSets[0].entry_list               = nset_nodes;
+    nodeSets[0].extra_list               = NULL;
+    nodeSets[0].distribution_factor_list = NULL;
+
+    edgeSets[0].type                     = EX_EDGE_SET;
+    edgeSets[0].id                       = 1200;
+    edgeSets[0].num_entry                = 6;
+    edgeSets[0].num_distribution_factor  = 6;
+    edgeSets[0].entry_list               = eset_edges;
+    edgeSets[0].extra_list               = eset_orient;
+    edgeSets[0].distribution_factor_list = eset_df;
+
+    faceSets[0].type                     = EX_FACE_SET;
+    faceSets[0].id                       = 1400;
+    faceSets[0].num_entry                = 2;
+    faceSets[0].num_distribution_factor  = 0;
+    faceSets[0].entry_list               = fset_faces;
+    faceSets[0].extra_list               = fset_orient;
+    faceSets[0].distribution_factor_list = NULL;
+
+    sideSets[0].type                     = EX_SIDE_SET;
+    sideSets[0].id                       = 1400;
+    sideSets[0].num_entry                = 5;
+    sideSets[0].num_distribution_factor  = 0;
+    sideSets[0].entry_list               = sset_elems;
+    sideSets[0].extra_list               = sset_sides;
+    sideSets[0].distribution_factor_list = NULL;
+
+    elemSets[0].type                     = EX_ELEM_SET;
+    elemSets[0].id                       = 1800;
+    elemSets[0].num_entry                = 1;
+    elemSets[0].num_distribution_factor  = 0;
+    elemSets[0].entry_list               = &elset_elems[0];
+    elemSets[0].extra_list               = NULL;
+    elemSets[0].distribution_factor_list = NULL;
+
+    elemSets[1].type                     = EX_ELEM_SET;
+    elemSets[1].id                       = 1900;
+    elemSets[1].num_entry                = 1;
+    elemSets[1].num_distribution_factor  = 0;
+    elemSets[1].entry_list               = &elset_elems[1];
+    elemSets[1].extra_list               = NULL;
+    elemSets[1].distribution_factor_list = NULL;
+
+    if (concatSets) {
+      EXCHECK(ex_put_sets(exoid, 1 + 2 + 1 + 1 + 1, allSets),
+              "Unable to output concatenated sets.\n");
+    }
+    else {
+      EXCHECK(ex_put_sets(exoid, 1, nodeSets), "Unable to write node sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, edgeSets), "Unable to write edge sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, faceSets), "Unable to write face sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, sideSets), "Unable to write side sets.\n");
+      EXCHECK(ex_put_sets(exoid, 2, elemSets), "Unable to write element sets.\n");
+    }
+  }
+
+  /*                  =============== Result variable params ========= */
+  /* *** NEW API *** */
+  if (concatResult) {
+    EXCHECK(ex_put_all_var_param_ext(exoid, &varParams),
+            "Unable to write result variable parameter information.\n");
+  }
+  else {
+    EXCHECK(ex_put_variable_param(exoid, EX_GLOBAL, 2),
+            "Unable to write global result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_NODAL, 1),
+            "Unable to write nodal result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_ELEM_BLOCK, 1),
+            "Unable to write element result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_EDGE_BLOCK, 2),
+            "Unable to write edge result variable parameters.\n");
+//    EXCHECK(ex_put_variable_param(exoid, EX_FACE_BLOCK, 2),
+//            "Unable to write face result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_FACE_BLOCK, 1),
+            "Unable to write face result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_FACE_SET, 1),
+            "Unable to write faceset result variable parameters.\n");
+  }
+
+  /*                  =============== Result variable names ========== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_variable_name(exoid, EX_GLOBAL, 1, "CALIBER"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_GLOBAL, 2, "GUNPOWDER"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_NODAL, 1, "RHO"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_EDGE_BLOCK, 1, "GAMMA1"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_EDGE_BLOCK, 2, "GAMMA2"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_FACE_BLOCK, 1, "PHI"), "Unable to write variable name.\n");
+//  EXCHECK(ex_put_variable_name(exoid, EX_FACE_BLOCK, 2, "PHI"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_ELEM_BLOCK, 1, "EPSTRN"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_FACE_SET, 1, "PHI0"), "Unable to write variable name.\n");
+
+  /*                  =============== Result variable values ========= */
+  t = 1.;
+  /* *** NEW API *** */
+  EXCHECK(ex_put_time(exoid, 1, &t), "Unable to write time value.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_GLOBAL, 1, 0 /*N/A*/, 2, vals_glo_var[0]),
+          "Unable to write global var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_EDGE_BLOCK, 1, 100, 20, vals_edge_var1eb1[0]),
+          "Unable to write edge block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_EDGE_BLOCK, 2, 100, 20, vals_edge_var2eb1[0]),
+          "Unable to write edge block 1 var 2.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 1, 500, 2, vals_face_var1fb1[0]),
+          "Unable to write face block 1 var 1.\n");
+//  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 2, 700, 8, vals_face_var1fb3[0]),
+//          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 1, 700, 8, vals_face_var1fb3[0]),
+          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_ELEM_BLOCK, 1, 200, 2, vals_elem_var1eb1[0]),
+          "Unable to write elem block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_SET, 1, 1400, 2, vals_fset_var1fs1[0]),
+          "Unable to write face set 1 var 1.\n");
+
+  t = 2.;
+  EXCHECK(ex_put_time(exoid, 2, &t), "Unable to write time value.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_GLOBAL, 1, 0 /*N/A*/, 2, vals_glo_var[1]),
+          "Unable to write global var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_EDGE_BLOCK, 1, 100, 20, vals_edge_var1eb1[1]),
+          "Unable to write edge block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_EDGE_BLOCK, 2, 100, 20, vals_edge_var2eb1[1]),
+          "Unable to write edge block 1 var 2.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 1, 500, 2, vals_face_var1fb1[1]),
+          "Unable to write face block 1 var 1.\n");
+//  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 2, 700, 8, vals_face_var1fb3[1]),
+//          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 1, 700, 8, vals_face_var1fb3[1]),
+          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_ELEM_BLOCK, 1, 200, 2, vals_elem_var1eb1[1]),
+          "Unable to write elem block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_SET, 1, 1400, 2, vals_fset_var1fs1[1]),
+          "Unable to write face set 1 var 1.\n");
+
+  EXCHECK(ex_put_var(exoid, 1, EX_NODAL, 1, 1, 12, vals_nod_var[0]),
+          "Unable to write nodal var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_NODAL, 1, 1, 12, vals_nod_var[1]),
+          "Unable to write nodal var 1.\n");
+
+  EXCHECK(ex_close(exoid), "Unable to close database.\n");
+
+  free(varParams.edge_var_tab);
+  free(varParams.face_var_tab);
+  free(varParams.elem_var_tab);
+  free(varParams.fset_var_tab);
+  return 0;
+}
+
+int create_edge_block_diff_file(int argc, char *argv[])
+{
+  int exoid;
+  int appWordSize  = 8;
+  int diskWordSize = 8;
+  /*  int concatBlocks = ex_have_arg( argc, argv, "-pcab" ); */
+  int    concatSets   = ex_have_arg(argc, argv, "-pcset");
+  int    concatResult = ex_have_arg(argc, argv, "-pvpax");
+  double t;
+
+  ex_init_params modelParams = {
+      "CreateEdgeFace Test", /* title */
+      3,                     /* num_dim */
+      12,                    /* num_nodes */
+      20,                    /* num_edge */
+      1,                     /* num_edge_blk */
+      11,                    /* num_face */
+      3,                     /* num_face_blk */
+      3,                     /* num_elem */
+      2,                     /* num_elem_blk */
+      1,                     /* num_node_sets */
+      1,                     /* num_edge_sets */
+      1,                     /* num_face_sets */
+      1,                     /* num_side_sets */
+      2,                     /* num_elem_sets */
+      1,                     /* num_node_map */
+      1,                     /* num_edge_map */
+      1,                     /* num_face_map */
+      1,                     /* num_elem_map */
+  };
+
+  ex_block edgeBlocks[1];
+  ex_block faceBlocks[3];
+  ex_block elemBlocks[2];
+
+  ex_var_params varParams;
+
+  ex_opts(EX_VERBOSE | EX_ABORT);
+
+  exoid = ex_create(EX_TEST_EDGE_DIFF_FILENAME, EX_CLOBBER, &appWordSize, &diskWordSize);
+  if (exoid <= 0) {
+    fprintf(stderr, "Unable to open \"%s\" for writing.\n", EX_TEST_EDGE_DIFF_FILENAME);
+    return 1;
+  }
+
+  edgeBlocks[0].type                = EX_EDGE_BLOCK;
+  edgeBlocks[0].id                  = 100;
+  edgeBlocks[0].num_entry           = 20;
+  edgeBlocks[0].num_nodes_per_entry = 2;
+  edgeBlocks[0].num_attribute       = 1;
+  ex_copy_string(edgeBlocks[0].topology, "EDGE2", MAX_STR_LENGTH + 1);
+
+  faceBlocks[0].type                = EX_FACE_BLOCK;
+  faceBlocks[0].id                  = 500;
+  faceBlocks[0].num_entry           = 2;
+  faceBlocks[0].num_nodes_per_entry = 4;
+  faceBlocks[0].num_attribute       = 1;
+  ex_copy_string(faceBlocks[0].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  faceBlocks[1].type                = EX_FACE_BLOCK;
+  faceBlocks[1].id                  = 600;
+  faceBlocks[1].num_entry           = 1;
+  faceBlocks[1].num_nodes_per_entry = 4;
+  faceBlocks[1].num_attribute       = 1;
+  ex_copy_string(faceBlocks[1].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  faceBlocks[2].type                = EX_FACE_BLOCK;
+  faceBlocks[2].id                  = 700;
+  faceBlocks[2].num_entry           = 8;
+  faceBlocks[2].num_nodes_per_entry = 4;
+  faceBlocks[2].num_attribute       = 1;
+  ex_copy_string(faceBlocks[2].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  elemBlocks[0].type                = EX_ELEM_BLOCK;
+  elemBlocks[0].id                  = 200;
+  elemBlocks[0].num_entry           = 2;
+  elemBlocks[0].num_nodes_per_entry = 8;
+  elemBlocks[0].num_edges_per_entry = 12;
+  elemBlocks[0].num_faces_per_entry = 6;
+  elemBlocks[0].num_attribute       = 2;
+  ex_copy_string(elemBlocks[0].topology, "HEX8", MAX_STR_LENGTH + 1);
+
+  elemBlocks[1].type                = EX_ELEM_BLOCK;
+  elemBlocks[1].id                  = 201;
+  elemBlocks[1].num_entry           = 1;
+  elemBlocks[1].num_nodes_per_entry = 4;
+  elemBlocks[1].num_edges_per_entry = 0;
+  elemBlocks[1].num_faces_per_entry = 0;
+  elemBlocks[1].num_attribute       = 0;
+  ex_copy_string(elemBlocks[1].topology, "TET4", MAX_STR_LENGTH + 1);
+
+  varParams.edge_var_tab  = (int *)malloc(2 * sizeof(int));
+  varParams.face_var_tab  = (int *)malloc(3 * sizeof(int));
+  varParams.elem_var_tab  = (int *)malloc(2 * sizeof(int));
+  varParams.nset_var_tab  = (int *)0;
+  varParams.eset_var_tab  = (int *)0;
+  varParams.fset_var_tab  = (int *)malloc(1 * sizeof(int));
+  varParams.sset_var_tab  = (int *)0;
+  varParams.elset_var_tab = (int *)0;
+
+  varParams.num_glob        = 2;
+  varParams.num_node        = 1;
+  varParams.num_edge        = 2;
+  varParams.edge_var_tab[0] = 1;
+  varParams.edge_var_tab[1] = 1;
+  varParams.num_face        = 1;
+  varParams.face_var_tab[0] = 1;
+  varParams.face_var_tab[1] = 1;
+  varParams.face_var_tab[2] = 1;
+  varParams.num_elem        = 1;
+  varParams.elem_var_tab[0] = 1;
+  varParams.elem_var_tab[1] = 0;
+  varParams.num_nset        = 0;
+  varParams.num_eset        = 0;
+  ;
+  varParams.num_fset        = 1;
+  varParams.fset_var_tab[0] = 1;
+  varParams.num_sset        = 0;
+  varParams.num_elset       = 0;
+
+  EXCHECK(ex_put_init_ext(exoid, &modelParams), "Unable to initialize database.\n");
+
+  {
+    int blk;
+    for (blk = 0; blk < modelParams.num_edge_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, edgeBlocks[blk]), "Unable to write edge block");
+    }
+    for (blk = 0; blk < modelParams.num_face_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, faceBlocks[blk]), "Unable to write face block");
+    }
+    for (blk = 0; blk < modelParams.num_elem_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, elemBlocks[blk]), "Unable to write elem block");
+    }
+  }
+
+  EXCHECK(ex_put_coord(exoid, (void *)coordsX, (void *)coordsY, (void *)coordsZ),
+          "Unable to write coordinates.\n");
+
+  EXCHECK(ex_put_coord_names(exoid, (char **)coordsNames), "Unable to write coordinate names.\n");
+
+  /*                  =============== Connectivity  ================== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, ebconn1, 0, 0),
+          "Unable to write edge block connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[0].id, fbconn1, 0, 0),
+          "Unable to write face block 1 connectivity.\n");
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[1].id, fbconn2, 0, 0),
+          "Unable to write face block 2 connectivity.\n");
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[2].id, fbconn3, 0, 0),
+          "Unable to write face block 3 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, conn1, econn1, fconn1),
+          "Unable to write elem block 1 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_ELEM_BLOCK, elemBlocks[1].id, conn2, 0, 0),
+          "Unable to write elem block 2 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_EDGE_BLOCK, (char **)edblk_names),
+          "Unable to write edge block names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_BLOCK, (char **)fablk_names),
+          "Unable to write face block names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_BLOCK, (char **)eblk_names),
+          "Unable to write element block names.\n");
+
+  /*                  =============== Number Maps   ================== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_num_map(exoid, EX_NODE_MAP, 300, nmap1), "Unable to write node map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_EDGE_MAP, 800, edmap1), "Unable to write edge map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_FACE_MAP, 900, famap1), "Unable to write face map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_ELEM_MAP, 400, emap1), "Unable to write element map.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_NODE_MAP, (char **)nmap_names),
+          "Unable to write node map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_EDGE_MAP, (char **)edmap_names),
+          "Unable to write edge map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_MAP, (char **)famap_names),
+          "Unable to write face map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_MAP, (char **)emap_names),
+          "Unable to write element map names.\n");
+
+  /*                 =============== Attribute names ================ */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, (char **)edge_attr_names1),
+          "Unable to write edge block 1 attribute names.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[0].id, (char **)face_attr_names1),
+          "Unable to write face block 1 attribute names.\n");
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[1].id, (char **)face_attr_names2),
+          "Unable to write face block 1 attribute names.\n");
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[2].id, (char **)face_attr_names3),
+          "Unable to write face block 1 attribute names.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, (char **)elem_attr_names1),
+          "Unable to write elem block 1 attribute names.\n");
+
+  /*                  =============== Attribute values =============== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, edge_attr_values1),
+          "Unable to write edge block 1 attribute values.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[0].id, face_attr_values1),
+          "Unable to write face block 1 attribute values.\n");
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[1].id, face_attr_values2),
+          "Unable to write face block 1 attribute values.\n");
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[2].id, face_attr_values3),
+          "Unable to write face block 1 attribute values.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, elem_attr_values1),
+          "Unable to write elem block 1 attribute values.\n");
+
+  /*                  =============== Set parameters ================= */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_NODE_SET, (char **)nset_names),
+          "Unable to write node set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_EDGE_SET, (char **)eset_names),
+          "Unable to write edge set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_SET, (char **)fset_names),
+          "Unable to write face set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_SIDE_SET, (char **)sset_names),
+          "Unable to write side set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_SET, (char **)elset_names),
+          "Unable to write element set names.\n");
+
+  {
+    ex_set allSets[1 + 1 + 1 + 1 + 2];
+
+    ex_set *nodeSets = &allSets[0];
+    ex_set *edgeSets = &allSets[1];
+    ex_set *faceSets = &allSets[2];
+    ex_set *sideSets = &allSets[3];
+    ex_set *elemSets = &allSets[4];
+
+    nodeSets[0].type                     = EX_NODE_SET;
+    nodeSets[0].id                       = 1000;
+    nodeSets[0].num_entry                = 3;
+    nodeSets[0].num_distribution_factor  = 0;
+    nodeSets[0].entry_list               = nset_nodes;
+    nodeSets[0].extra_list               = NULL;
+    nodeSets[0].distribution_factor_list = NULL;
+
+    edgeSets[0].type                     = EX_EDGE_SET;
+    edgeSets[0].id                       = 1200;
+    edgeSets[0].num_entry                = 6;
+    edgeSets[0].num_distribution_factor  = 6;
+    edgeSets[0].entry_list               = eset_edges;
+    edgeSets[0].extra_list               = eset_orient;
+    edgeSets[0].distribution_factor_list = eset_df;
+
+    faceSets[0].type                     = EX_FACE_SET;
+    faceSets[0].id                       = 1400;
+    faceSets[0].num_entry                = 2;
+    faceSets[0].num_distribution_factor  = 0;
+    faceSets[0].entry_list               = fset_faces;
+    faceSets[0].extra_list               = fset_orient;
+    faceSets[0].distribution_factor_list = NULL;
+
+    sideSets[0].type                     = EX_SIDE_SET;
+    sideSets[0].id                       = 1400;
+    sideSets[0].num_entry                = 5;
+    sideSets[0].num_distribution_factor  = 0;
+    sideSets[0].entry_list               = sset_elems;
+    sideSets[0].extra_list               = sset_sides;
+    sideSets[0].distribution_factor_list = NULL;
+
+    elemSets[0].type                     = EX_ELEM_SET;
+    elemSets[0].id                       = 1800;
+    elemSets[0].num_entry                = 1;
+    elemSets[0].num_distribution_factor  = 0;
+    elemSets[0].entry_list               = &elset_elems[0];
+    elemSets[0].extra_list               = NULL;
+    elemSets[0].distribution_factor_list = NULL;
+
+    elemSets[1].type                     = EX_ELEM_SET;
+    elemSets[1].id                       = 1900;
+    elemSets[1].num_entry                = 1;
+    elemSets[1].num_distribution_factor  = 0;
+    elemSets[1].entry_list               = &elset_elems[1];
+    elemSets[1].extra_list               = NULL;
+    elemSets[1].distribution_factor_list = NULL;
+
+    if (concatSets) {
+      EXCHECK(ex_put_sets(exoid, 1 + 2 + 1 + 1 + 1, allSets),
+              "Unable to output concatenated sets.\n");
+    }
+    else {
+      EXCHECK(ex_put_sets(exoid, 1, nodeSets), "Unable to write node sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, edgeSets), "Unable to write edge sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, faceSets), "Unable to write face sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, sideSets), "Unable to write side sets.\n");
+      EXCHECK(ex_put_sets(exoid, 2, elemSets), "Unable to write element sets.\n");
+    }
+  }
+
+  /*                  =============== Result variable params ========= */
+  /* *** NEW API *** */
+  if (concatResult) {
+    EXCHECK(ex_put_all_var_param_ext(exoid, &varParams),
+            "Unable to write result variable parameter information.\n");
+  }
+  else {
+    EXCHECK(ex_put_variable_param(exoid, EX_GLOBAL, 2),
+            "Unable to write global result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_NODAL, 1),
+            "Unable to write nodal result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_ELEM_BLOCK, 1),
+            "Unable to write element result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_EDGE_BLOCK, 2),
+            "Unable to write edge result variable parameters.\n");
+//    EXCHECK(ex_put_variable_param(exoid, EX_FACE_BLOCK, 2),
+//            "Unable to write face result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_FACE_BLOCK, 1),
+            "Unable to write face result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_FACE_SET, 1),
+            "Unable to write faceset result variable parameters.\n");
+  }
+
+  /*                  =============== Result variable names ========== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_variable_name(exoid, EX_GLOBAL, 1, "CALIBER"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_GLOBAL, 2, "GUNPOWDER"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_NODAL, 1, "RHO"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_EDGE_BLOCK, 1, "GAMMA1"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_EDGE_BLOCK, 2, "GAMMA2"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_FACE_BLOCK, 1, "PHI"), "Unable to write variable name.\n");
+//  EXCHECK(ex_put_variable_name(exoid, EX_FACE_BLOCK, 2, "PHI"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_ELEM_BLOCK, 1, "EPSTRN"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_FACE_SET, 1, "PHI0"), "Unable to write variable name.\n");
+
+  /*                  =============== Result variable values ========= */
+  t = 1.;
+  /* *** NEW API *** */
+  EXCHECK(ex_put_time(exoid, 1, &t), "Unable to write time value.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_GLOBAL, 1, 0 /*N/A*/, 2, vals_glo_var[0]),
+          "Unable to write global var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_EDGE_BLOCK, 1, 100, 20, diff_vals_edge_var1eb1[0]),
+          "Unable to write edge block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_EDGE_BLOCK, 2, 100, 20, vals_edge_var2eb1[0]),
+          "Unable to write edge block 1 var 2.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 1, 500, 2, vals_face_var1fb1[0]),
+          "Unable to write face block 1 var 1.\n");
+//  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 2, 700, 8, vals_face_var1fb3[0]),
+//          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 1, 700, 8, vals_face_var1fb3[0]),
+          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_ELEM_BLOCK, 1, 200, 2, vals_elem_var1eb1[0]),
+          "Unable to write elem block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_SET, 1, 1400, 2, vals_fset_var1fs1[0]),
+          "Unable to write face set 1 var 1.\n");
+
+  t = 2.;
+  EXCHECK(ex_put_time(exoid, 2, &t), "Unable to write time value.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_GLOBAL, 1, 0 /*N/A*/, 2, vals_glo_var[1]),
+          "Unable to write global var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_EDGE_BLOCK, 1, 100, 20, diff_vals_edge_var1eb1[1]),
+          "Unable to write edge block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_EDGE_BLOCK, 2, 100, 20, vals_edge_var2eb1[1]),
+          "Unable to write edge block 1 var 2.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 1, 500, 2, vals_face_var1fb1[1]),
+          "Unable to write face block 1 var 1.\n");
+//  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 2, 700, 8, vals_face_var1fb3[1]),
+//          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 1, 700, 8, vals_face_var1fb3[1]),
+          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_ELEM_BLOCK, 1, 200, 2, vals_elem_var1eb1[1]),
+          "Unable to write elem block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_SET, 1, 1400, 2, vals_fset_var1fs1[1]),
+          "Unable to write face set 1 var 1.\n");
+
+  EXCHECK(ex_put_var(exoid, 1, EX_NODAL, 1, 1, 12, vals_nod_var[0]),
+          "Unable to write nodal var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_NODAL, 1, 1, 12, vals_nod_var[1]),
+          "Unable to write nodal var 1.\n");
+
+  EXCHECK(ex_close(exoid), "Unable to close database.\n");
+
+  free(varParams.edge_var_tab);
+  free(varParams.face_var_tab);
+  free(varParams.elem_var_tab);
+  free(varParams.fset_var_tab);
+  return 0;
+}
+
+int create_face_block_diff_file(int argc, char *argv[])
+{
+  int exoid;
+  int appWordSize  = 8;
+  int diskWordSize = 8;
+  /*  int concatBlocks = ex_have_arg( argc, argv, "-pcab" ); */
+  int    concatSets   = ex_have_arg(argc, argv, "-pcset");
+  int    concatResult = ex_have_arg(argc, argv, "-pvpax");
+  double t;
+
+  ex_init_params modelParams = {
+      "CreateEdgeFace Test", /* title */
+      3,                     /* num_dim */
+      12,                    /* num_nodes */
+      20,                    /* num_edge */
+      1,                     /* num_edge_blk */
+      11,                    /* num_face */
+      3,                     /* num_face_blk */
+      3,                     /* num_elem */
+      2,                     /* num_elem_blk */
+      1,                     /* num_node_sets */
+      1,                     /* num_edge_sets */
+      1,                     /* num_face_sets */
+      1,                     /* num_side_sets */
+      2,                     /* num_elem_sets */
+      1,                     /* num_node_map */
+      1,                     /* num_edge_map */
+      1,                     /* num_face_map */
+      1,                     /* num_elem_map */
+  };
+
+  ex_block edgeBlocks[1];
+  ex_block faceBlocks[3];
+  ex_block elemBlocks[2];
+
+  ex_var_params varParams;
+
+  ex_opts(EX_VERBOSE | EX_ABORT);
+
+  exoid = ex_create(EX_TEST_FACE_DIFF_FILENAME, EX_CLOBBER, &appWordSize, &diskWordSize);
+  if (exoid <= 0) {
+    fprintf(stderr, "Unable to open \"%s\" for writing.\n", EX_TEST_FACE_DIFF_FILENAME);
+    return 1;
+  }
+
+  edgeBlocks[0].type                = EX_EDGE_BLOCK;
+  edgeBlocks[0].id                  = 100;
+  edgeBlocks[0].num_entry           = 20;
+  edgeBlocks[0].num_nodes_per_entry = 2;
+  edgeBlocks[0].num_attribute       = 1;
+  ex_copy_string(edgeBlocks[0].topology, "EDGE2", MAX_STR_LENGTH + 1);
+
+  faceBlocks[0].type                = EX_FACE_BLOCK;
+  faceBlocks[0].id                  = 500;
+  faceBlocks[0].num_entry           = 2;
+  faceBlocks[0].num_nodes_per_entry = 4;
+  faceBlocks[0].num_attribute       = 1;
+  ex_copy_string(faceBlocks[0].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  faceBlocks[1].type                = EX_FACE_BLOCK;
+  faceBlocks[1].id                  = 600;
+  faceBlocks[1].num_entry           = 1;
+  faceBlocks[1].num_nodes_per_entry = 4;
+  faceBlocks[1].num_attribute       = 1;
+  ex_copy_string(faceBlocks[1].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  faceBlocks[2].type                = EX_FACE_BLOCK;
+  faceBlocks[2].id                  = 700;
+  faceBlocks[2].num_entry           = 8;
+  faceBlocks[2].num_nodes_per_entry = 4;
+  faceBlocks[2].num_attribute       = 1;
+  ex_copy_string(faceBlocks[2].topology, "QUAD4", MAX_STR_LENGTH + 1);
+
+  elemBlocks[0].type                = EX_ELEM_BLOCK;
+  elemBlocks[0].id                  = 200;
+  elemBlocks[0].num_entry           = 2;
+  elemBlocks[0].num_nodes_per_entry = 8;
+  elemBlocks[0].num_edges_per_entry = 12;
+  elemBlocks[0].num_faces_per_entry = 6;
+  elemBlocks[0].num_attribute       = 2;
+  ex_copy_string(elemBlocks[0].topology, "HEX8", MAX_STR_LENGTH + 1);
+
+  elemBlocks[1].type                = EX_ELEM_BLOCK;
+  elemBlocks[1].id                  = 201;
+  elemBlocks[1].num_entry           = 1;
+  elemBlocks[1].num_nodes_per_entry = 4;
+  elemBlocks[1].num_edges_per_entry = 0;
+  elemBlocks[1].num_faces_per_entry = 0;
+  elemBlocks[1].num_attribute       = 0;
+  ex_copy_string(elemBlocks[1].topology, "TET4", MAX_STR_LENGTH + 1);
+
+  varParams.edge_var_tab  = (int *)malloc(2 * sizeof(int));
+  varParams.face_var_tab  = (int *)malloc(3 * sizeof(int));
+  varParams.elem_var_tab  = (int *)malloc(2 * sizeof(int));
+  varParams.nset_var_tab  = (int *)0;
+  varParams.eset_var_tab  = (int *)0;
+  varParams.fset_var_tab  = (int *)malloc(1 * sizeof(int));
+  varParams.sset_var_tab  = (int *)0;
+  varParams.elset_var_tab = (int *)0;
+
+  varParams.num_glob        = 2;
+  varParams.num_node        = 1;
+  varParams.num_edge        = 2;
+  varParams.edge_var_tab[0] = 1;
+  varParams.edge_var_tab[1] = 1;
+  varParams.num_face        = 1;
+  varParams.face_var_tab[0] = 1;
+  varParams.face_var_tab[1] = 1;
+  varParams.face_var_tab[2] = 1;
+  varParams.num_elem        = 1;
+  varParams.elem_var_tab[0] = 1;
+  varParams.elem_var_tab[1] = 0;
+  varParams.num_nset        = 0;
+  varParams.num_eset        = 0;
+  ;
+  varParams.num_fset        = 1;
+  varParams.fset_var_tab[0] = 1;
+  varParams.num_sset        = 0;
+  varParams.num_elset       = 0;
+
+  EXCHECK(ex_put_init_ext(exoid, &modelParams), "Unable to initialize database.\n");
+
+  {
+    int blk;
+    for (blk = 0; blk < modelParams.num_edge_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, edgeBlocks[blk]), "Unable to write edge block");
+    }
+    for (blk = 0; blk < modelParams.num_face_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, faceBlocks[blk]), "Unable to write face block");
+    }
+    for (blk = 0; blk < modelParams.num_elem_blk; ++blk) {
+      EXCHECK(ex_put_block_param(exoid, elemBlocks[blk]), "Unable to write elem block");
+    }
+  }
+
+  EXCHECK(ex_put_coord(exoid, (void *)coordsX, (void *)coordsY, (void *)coordsZ),
+          "Unable to write coordinates.\n");
+
+  EXCHECK(ex_put_coord_names(exoid, (char **)coordsNames), "Unable to write coordinate names.\n");
+
+  /*                  =============== Connectivity  ================== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, ebconn1, 0, 0),
+          "Unable to write edge block connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[0].id, fbconn1, 0, 0),
+          "Unable to write face block 1 connectivity.\n");
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[1].id, fbconn2, 0, 0),
+          "Unable to write face block 2 connectivity.\n");
+  EXCHECK(ex_put_conn(exoid, EX_FACE_BLOCK, faceBlocks[2].id, fbconn3, 0, 0),
+          "Unable to write face block 3 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, conn1, econn1, fconn1),
+          "Unable to write elem block 1 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_conn(exoid, EX_ELEM_BLOCK, elemBlocks[1].id, conn2, 0, 0),
+          "Unable to write elem block 2 connectivity.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_EDGE_BLOCK, (char **)edblk_names),
+          "Unable to write edge block names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_BLOCK, (char **)fablk_names),
+          "Unable to write face block names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_BLOCK, (char **)eblk_names),
+          "Unable to write element block names.\n");
+
+  /*                  =============== Number Maps   ================== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_num_map(exoid, EX_NODE_MAP, 300, nmap1), "Unable to write node map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_EDGE_MAP, 800, edmap1), "Unable to write edge map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_FACE_MAP, 900, famap1), "Unable to write face map.\n");
+  EXCHECK(ex_put_num_map(exoid, EX_ELEM_MAP, 400, emap1), "Unable to write element map.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_NODE_MAP, (char **)nmap_names),
+          "Unable to write node map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_EDGE_MAP, (char **)edmap_names),
+          "Unable to write edge map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_MAP, (char **)famap_names),
+          "Unable to write face map names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_MAP, (char **)emap_names),
+          "Unable to write element map names.\n");
+
+  /*                 =============== Attribute names ================ */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, (char **)edge_attr_names1),
+          "Unable to write edge block 1 attribute names.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[0].id, (char **)face_attr_names1),
+          "Unable to write face block 1 attribute names.\n");
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[1].id, (char **)face_attr_names2),
+          "Unable to write face block 1 attribute names.\n");
+  EXCHECK(ex_put_attr_names(exoid, EX_FACE_BLOCK, faceBlocks[2].id, (char **)face_attr_names3),
+          "Unable to write face block 1 attribute names.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr_names(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, (char **)elem_attr_names1),
+          "Unable to write elem block 1 attribute names.\n");
+
+  /*                  =============== Attribute values =============== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_EDGE_BLOCK, edgeBlocks[0].id, edge_attr_values1),
+          "Unable to write edge block 1 attribute values.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[0].id, face_attr_values1),
+          "Unable to write face block 1 attribute values.\n");
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[1].id, face_attr_values2),
+          "Unable to write face block 1 attribute values.\n");
+  EXCHECK(ex_put_attr(exoid, EX_FACE_BLOCK, faceBlocks[2].id, face_attr_values3),
+          "Unable to write face block 1 attribute values.\n");
+
+  /* *** NEW API *** */
+  EXCHECK(ex_put_attr(exoid, EX_ELEM_BLOCK, elemBlocks[0].id, elem_attr_values1),
+          "Unable to write elem block 1 attribute values.\n");
+
+  /*                  =============== Set parameters ================= */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_names(exoid, EX_NODE_SET, (char **)nset_names),
+          "Unable to write node set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_EDGE_SET, (char **)eset_names),
+          "Unable to write edge set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_FACE_SET, (char **)fset_names),
+          "Unable to write face set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_SIDE_SET, (char **)sset_names),
+          "Unable to write side set names.\n");
+  EXCHECK(ex_put_names(exoid, EX_ELEM_SET, (char **)elset_names),
+          "Unable to write element set names.\n");
+
+  {
+    ex_set allSets[1 + 1 + 1 + 1 + 2];
+
+    ex_set *nodeSets = &allSets[0];
+    ex_set *edgeSets = &allSets[1];
+    ex_set *faceSets = &allSets[2];
+    ex_set *sideSets = &allSets[3];
+    ex_set *elemSets = &allSets[4];
+
+    nodeSets[0].type                     = EX_NODE_SET;
+    nodeSets[0].id                       = 1000;
+    nodeSets[0].num_entry                = 3;
+    nodeSets[0].num_distribution_factor  = 0;
+    nodeSets[0].entry_list               = nset_nodes;
+    nodeSets[0].extra_list               = NULL;
+    nodeSets[0].distribution_factor_list = NULL;
+
+    edgeSets[0].type                     = EX_EDGE_SET;
+    edgeSets[0].id                       = 1200;
+    edgeSets[0].num_entry                = 6;
+    edgeSets[0].num_distribution_factor  = 6;
+    edgeSets[0].entry_list               = eset_edges;
+    edgeSets[0].extra_list               = eset_orient;
+    edgeSets[0].distribution_factor_list = eset_df;
+
+    faceSets[0].type                     = EX_FACE_SET;
+    faceSets[0].id                       = 1400;
+    faceSets[0].num_entry                = 2;
+    faceSets[0].num_distribution_factor  = 0;
+    faceSets[0].entry_list               = fset_faces;
+    faceSets[0].extra_list               = fset_orient;
+    faceSets[0].distribution_factor_list = NULL;
+
+    sideSets[0].type                     = EX_SIDE_SET;
+    sideSets[0].id                       = 1400;
+    sideSets[0].num_entry                = 5;
+    sideSets[0].num_distribution_factor  = 0;
+    sideSets[0].entry_list               = sset_elems;
+    sideSets[0].extra_list               = sset_sides;
+    sideSets[0].distribution_factor_list = NULL;
+
+    elemSets[0].type                     = EX_ELEM_SET;
+    elemSets[0].id                       = 1800;
+    elemSets[0].num_entry                = 1;
+    elemSets[0].num_distribution_factor  = 0;
+    elemSets[0].entry_list               = &elset_elems[0];
+    elemSets[0].extra_list               = NULL;
+    elemSets[0].distribution_factor_list = NULL;
+
+    elemSets[1].type                     = EX_ELEM_SET;
+    elemSets[1].id                       = 1900;
+    elemSets[1].num_entry                = 1;
+    elemSets[1].num_distribution_factor  = 0;
+    elemSets[1].entry_list               = &elset_elems[1];
+    elemSets[1].extra_list               = NULL;
+    elemSets[1].distribution_factor_list = NULL;
+
+    if (concatSets) {
+      EXCHECK(ex_put_sets(exoid, 1 + 2 + 1 + 1 + 1, allSets),
+              "Unable to output concatenated sets.\n");
+    }
+    else {
+      EXCHECK(ex_put_sets(exoid, 1, nodeSets), "Unable to write node sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, edgeSets), "Unable to write edge sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, faceSets), "Unable to write face sets.\n");
+      EXCHECK(ex_put_sets(exoid, 1, sideSets), "Unable to write side sets.\n");
+      EXCHECK(ex_put_sets(exoid, 2, elemSets), "Unable to write element sets.\n");
+    }
+  }
+
+  /*                  =============== Result variable params ========= */
+  /* *** NEW API *** */
+  if (concatResult) {
+    EXCHECK(ex_put_all_var_param_ext(exoid, &varParams),
+            "Unable to write result variable parameter information.\n");
+  }
+  else {
+    EXCHECK(ex_put_variable_param(exoid, EX_GLOBAL, 2),
+            "Unable to write global result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_NODAL, 1),
+            "Unable to write nodal result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_ELEM_BLOCK, 1),
+            "Unable to write element result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_EDGE_BLOCK, 2),
+            "Unable to write edge result variable parameters.\n");
+//    EXCHECK(ex_put_variable_param(exoid, EX_FACE_BLOCK, 2),
+//            "Unable to write face result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_FACE_BLOCK, 1),
+            "Unable to write face result variable parameters.\n");
+    EXCHECK(ex_put_variable_param(exoid, EX_FACE_SET, 1),
+            "Unable to write faceset result variable parameters.\n");
+  }
+
+  /*                  =============== Result variable names ========== */
+  /* *** NEW API *** */
+  EXCHECK(ex_put_variable_name(exoid, EX_GLOBAL, 1, "CALIBER"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_GLOBAL, 2, "GUNPOWDER"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_NODAL, 1, "RHO"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_EDGE_BLOCK, 1, "GAMMA1"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_EDGE_BLOCK, 2, "GAMMA2"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_FACE_BLOCK, 1, "PHI"), "Unable to write variable name.\n");
+//  EXCHECK(ex_put_variable_name(exoid, EX_FACE_BLOCK, 2, "PHI"), "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_ELEM_BLOCK, 1, "EPSTRN"),
+          "Unable to write variable name.\n");
+  EXCHECK(ex_put_variable_name(exoid, EX_FACE_SET, 1, "PHI0"), "Unable to write variable name.\n");
+
+  /*                  =============== Result variable values ========= */
+  t = 1.;
+  /* *** NEW API *** */
+  EXCHECK(ex_put_time(exoid, 1, &t), "Unable to write time value.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_GLOBAL, 1, 0 /*N/A*/, 2, vals_glo_var[0]),
+          "Unable to write global var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_EDGE_BLOCK, 1, 100, 20, vals_edge_var1eb1[0]),
+          "Unable to write edge block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_EDGE_BLOCK, 2, 100, 20, vals_edge_var2eb1[0]),
+          "Unable to write edge block 1 var 2.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 1, 500, 2, diff_vals_face_var1fb1[0]),
+          "Unable to write face block 1 var 1.\n");
+//  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 2, 700, 8, vals_face_var1fb3[0]),
+//          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_BLOCK, 1, 700, 8, vals_face_var1fb3[0]),
+          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_ELEM_BLOCK, 1, 200, 2, vals_elem_var1eb1[0]),
+          "Unable to write elem block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 1, EX_FACE_SET, 1, 1400, 2, vals_fset_var1fs1[0]),
+          "Unable to write face set 1 var 1.\n");
+
+  t = 2.;
+  EXCHECK(ex_put_time(exoid, 2, &t), "Unable to write time value.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_GLOBAL, 1, 0 /*N/A*/, 2, vals_glo_var[1]),
+          "Unable to write global var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_EDGE_BLOCK, 1, 100, 20, vals_edge_var1eb1[1]),
+          "Unable to write edge block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_EDGE_BLOCK, 2, 100, 20, vals_edge_var2eb1[1]),
+          "Unable to write edge block 1 var 2.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 1, 500, 2, diff_vals_face_var1fb1[1]),
+          "Unable to write face block 1 var 1.\n");
+//  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 2, 700, 8, vals_face_var1fb3[1]),
+//          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_BLOCK, 1, 700, 8, vals_face_var1fb3[1]),
+          "Unable to write face block 3 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_ELEM_BLOCK, 1, 200, 2, vals_elem_var1eb1[1]),
+          "Unable to write elem block 1 var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_FACE_SET, 1, 1400, 2, vals_fset_var1fs1[1]),
+          "Unable to write face set 1 var 1.\n");
+
+  EXCHECK(ex_put_var(exoid, 1, EX_NODAL, 1, 1, 12, vals_nod_var[0]),
+          "Unable to write nodal var 1.\n");
+  EXCHECK(ex_put_var(exoid, 2, EX_NODAL, 1, 1, 12, vals_nod_var[1]),
+          "Unable to write nodal var 1.\n");
+
+  EXCHECK(ex_close(exoid), "Unable to close database.\n");
+
+  free(varParams.edge_var_tab);
+  free(varParams.face_var_tab);
+  free(varParams.elem_var_tab);
+  free(varParams.fset_var_tab);
+  return 0;
+}
+
+#if !defined(USING_CMAKE)
+int main(int argc, char *argv[]) 
+{ 
+  int rc = 0;
+  rc = create_gold_file(argc, argv);
+  if (rc != 0) return rc;
+  rc = create_no_diff_file(argc, argv);
+  if (rc != 0) return rc;
+  rc = create_edge_block_diff_file(argc, argv);
+  if (rc != 0) return rc;
+  rc = create_face_block_diff_file(argc, argv);
+  if (rc != 0) return rc;
+  
+  return 0;
+}
+#endif


### PR DESCRIPTION
This PR adds edge/face variable comparison to exodiff.  The features are tested using a new test file generator that creates 4 exodus files.  The `exodiff_test_edge_face` ctest compares a base (gold) exodus file to exodus files with no diffs, edge diffs and face diffs.

Closes #201 
