### PR TITLE
Fixes for static libraries and Windows

### DIFF
--- a/cmake/tribits/common_tpls/find_modules/FindHDF5.cmake
+++ b/cmake/tribits/common_tpls/find_modules/FindHDF5.cmake
@@ -373,7 +373,7 @@ else()
       NO_MODULE)
 
     # If located a HDF5 configuration file
-    if (HDF5_FOUND)
+    if (HDF5_CONFIG)
 
       message(STATUS "Found CMake configuration file HDF5 ( directory ${HDF5_ROOT} )")
 
@@ -382,7 +382,15 @@ else()
       set(HDF5_IS_PARALLEL  ${HDF5_ENABLE_PARALLEL})
       set(HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIR})
 
-      set(HDF5_LIBRARIES "${HDF5_EXPORT_LIBRARIES}")
+      foreach(HDF5_TARGET_SUFFIX shared static)
+        if (TARGET hdf5_hl-${HDF5_TARGET_SUFFIX})
+          set(HDF5_LIBRARIES ${HDF5_LIBRARIES} hdf5_hl-${HDF5_TARGET_SUFFIX})
+        endif()
+        if (TARGET hdf5-${HDF5_TARGET_SUFFIX})
+          set(HDF5_LIBRARIES ${HDF5_LIBRARIES} hdf5-${HDF5_TARGET_SUFFIX})
+          break()
+        endif()
+      endforeach()
       if (HDF5_IS_PARALLEL)
         find_package(MPI)
         if (MPI_C_FOUND)
@@ -391,7 +399,7 @@ else()
       endif()
       set(HDF5_C_LIBRARIES "${HDF5_LIBRARIES}")
 
-    endif(HDF5_FOUND)  
+    endif(HDF5_CONFIG)
     
   endif(NOT HDF5_NO_HDF5_CMAKE)
 

--- a/cmake/tribits/common_tpls/find_modules/FindHDF5.cmake
+++ b/cmake/tribits/common_tpls/find_modules/FindHDF5.cmake
@@ -383,6 +383,12 @@ else()
       set(HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIR})
 
       set(HDF5_LIBRARIES "${HDF5_EXPORT_LIBRARIES}")
+      if (HDF5_IS_PARALLEL)
+        find_package(MPI)
+        if (MPI_C_FOUND)
+          set(HDF5_LIBRARIES ${HDF5_LIBRARIES} MPI::MPI_C)
+        endif()
+      endif()
       set(HDF5_C_LIBRARIES "${HDF5_LIBRARIES}")
 
     endif(HDF5_FOUND)  

--- a/cmake/tribits/common_tpls/find_modules/FindHDF5.cmake
+++ b/cmake/tribits/common_tpls/find_modules/FindHDF5.cmake
@@ -382,22 +382,8 @@ else()
       set(HDF5_IS_PARALLEL  ${HDF5_ENABLE_PARALLEL})
       set(HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIR})
 
-      # Loop through each possible target and 
-      # build the HDF5_LIBRARIES.
-      # Target names set by the HDF5 configuration file
-      set(HDF5_LIBRARIES)
-
-      foreach( _component ${HDF5_VALID_COMPONENTS} )
-        set(target ${HDF5_${_component}_TARGET})
-	if ( TARGET ${target} )
-	  set(HDF5_${_component}_LIBRARY ${target})
-	  list(APPEND HDF5_LIBRARIES ${HDF5_${_component}_LIBRARY})
-	endif()  
-      endforeach()
-
-      # Define HDF5_C_LIBRARIES to contain hdf5 and hdf5_hl C libraries
-      set(HDF5_C_LIBRARIES ${HDF5_HL_LIBRARY} ${HDF5_CLIBRARY})
-      
+      set(HDF5_LIBRARIES "${HDF5_EXPORT_LIBRARIES}")
+      set(HDF5_C_LIBRARIES "${HDF5_LIBRARIES}")
 
     endif(HDF5_FOUND)  
     

--- a/packages/seacas/libraries/ioss/src/Ioss_FaceGenerator.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_FaceGenerator.C
@@ -18,6 +18,7 @@
 #include <Ioss_Region.h>
 
 #include <algorithm>
+#include <numeric>
 #include <chrono>
 #include <fmt/format.h>
 #include <fmt/ostream.h>

--- a/packages/seacas/libraries/ioss/src/Ioss_ParallelUtils.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_ParallelUtils.h
@@ -126,11 +126,12 @@ namespace Ioss {
   inline MPI_Datatype mpi_type(double /*dummy*/) { return MPI_DOUBLE; }
   inline MPI_Datatype mpi_type(float /*dummy*/) { return MPI_FLOAT; }
   inline MPI_Datatype mpi_type(int /*dummy*/) { return MPI_INT; }
-  inline MPI_Datatype mpi_type(char /*dummy*/) { return MPI_CHAR; }
   inline MPI_Datatype mpi_type(long int /*dummy*/) { return MPI_LONG_LONG_INT; }
   inline MPI_Datatype mpi_type(long long int /*dummy*/) { return MPI_LONG_LONG_INT; }
   inline MPI_Datatype mpi_type(unsigned int /*dummy*/) { return MPI_UNSIGNED; }
   inline MPI_Datatype mpi_type(unsigned long int /*dummy*/) { return MPI_UNSIGNED_LONG; }
+  inline MPI_Datatype mpi_type(unsigned long long int /*dummy*/) { return MPI_UNSIGNED_LONG_LONG; }
+  inline MPI_Datatype mpi_type(char /*dummy*/) { return MPI_CHAR; }
 
   template <typename T>
   int MY_Alltoallv64(const std::vector<T> &sendbuf, const std::vector<int64_t> &sendcounts,

--- a/packages/seacas/libraries/ioss/src/Ioss_Utils.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Utils.C
@@ -46,8 +46,8 @@
 
 // For memory utilities...
 #if defined(_WIN32)
-#include <psapi.h>
 #include <windows.h>
+#include <psapi.h>
 #undef max
 
 #elif defined(__unix__) || defined(__unix) || defined(unix) ||                                     \

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_ParallelDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_ParallelDatabaseIO.C
@@ -29,7 +29,6 @@
 #include <numeric>
 #include <set>
 #include <string>
-#include <sys/select.h>
 #include <tokenize.h>
 #include <unistd.h>
 #include <utility>
@@ -450,12 +449,14 @@ namespace Ioex {
     // create an ifdef'd version of the fix which is only applied to the
     // buggy mpiio code.  Therefore, we always do chdir call.  Maybe in several
     // years, we can remove this code and everything will work...
+
+#ifndef _WIN32
     Ioss::FileInfo file(filename);
     std::string    path = file.pathname();
     filename            = file.tailname();
-
     char *current_cwd = getcwd(nullptr, 0);
     chdir(path.c_str());
+#endif
 
     bool do_timer = false;
     Ioss::Utils::check_set_bool_property(properties, "IOSS_TIME_FILE_OPEN_CLOSE", do_timer);
@@ -473,8 +474,10 @@ namespace Ioex {
       }
     }
 
+#ifndef _WIN32
     chdir(current_cwd);
     std::free(current_cwd);
+#endif
 
     bool is_ok = check_valid_file_ptr(write_message, error_msg, bad_count, abort_if_error);
 
@@ -542,12 +545,13 @@ namespace Ioex {
 
     std::string filename = get_dwname();
 
+#ifndef _WIN32
     Ioss::FileInfo file(filename);
     std::string    path = file.pathname();
     filename            = file.tailname();
-
     char *current_cwd = getcwd(nullptr, 0);
     chdir(path.c_str());
+#endif
 
     bool do_timer = false;
     Ioss::Utils::check_set_bool_property(properties, "IOSS_TIME_FILE_OPEN_CLOSE", do_timer);
@@ -585,8 +589,10 @@ namespace Ioex {
       }
     }
 
+#ifndef _WIN32
     chdir(current_cwd);
     std::free(current_cwd);
+#endif
 
     bool is_ok = check_valid_file_ptr(write_message, error_msg, bad_count, abort_if_error);
 


### PR DESCRIPTION
HDF5 calls their targets something based on both static/shared and component, so this makes it easier to find them by just letting HDF5 tell us what they are. This fixes the build for me when using all static libraries, because HDF5 is better able to include things like `zlib` in its exported targets.