### PR TITLE
EXODUS: ex_get_name now works with assemblies.

### DIFF
--- a/packages/seacas/libraries/exodus/src/ex_get_name.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2020 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2021 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -43,12 +43,10 @@ int ex_get_name(int exoid, ex_entity_type obj_type, ex_entity_id entity_id, char
   }
 
   switch (obj_type) {
-  case EX_ASSEMBLY:
-    snprintf(errmsg, MAX_ERR_LENGTH,
-             "ERROR: Assembly name is read using `ex_get_assembly()` function");
-    ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
-    EX_FUNC_LEAVE(EX_FATAL);
-    break;
+  case EX_ASSEMBLY: ;
+    ex_assembly assembly = {entity_id, name};
+    return ex_get_assembly(exoid, &assembly);
+
   case EX_ELEM_BLOCK: vobj = VAR_NAME_EL_BLK; break;
   case EX_EDGE_BLOCK: vobj = VAR_NAME_ED_BLK; break;
   case EX_FACE_BLOCK: vobj = VAR_NAME_FA_BLK; break;


### PR DESCRIPTION
Use the ex_get_assembly function to get the name of assemblies
in ex_get_name for consitency across the data structures.