### PR TITLE
exodus.py: Provide exodus.py with the get_assemblies function

### DIFF
--- a/packages/seacas/libraries/exodus/src/ex_get_assemblies.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_assemblies.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2020 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2021 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *

--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -1,5 +1,5 @@
 """
-exodus.py v 1.20.2 (seacas-beta) is a python wrapper of some of the exodus library
+exodus.py v 1.20.3 (seacas-beta) is a python wrapper of some of the exodus library
 (Python 3 Version)
 
 Exodus is a common database for multiple application codes (mesh
@@ -70,10 +70,10 @@ from enum import Enum
 
 EXODUS_PY_COPYRIGHT_AND_LICENSE = __doc__
 
-EXODUS_PY_VERSION = "1.20.2 (seacas-py3)"
+EXODUS_PY_VERSION = "1.20.3 (seacas-py3)"
 
 EXODUS_PY_COPYRIGHT = """
-You are using exodus.py v 1.20.2 (seacas-py3), a python wrapper of some of the exodus library.
+You are using exodus.py v 1.20.3 (seacas-py3), a python wrapper of some of the exodus library.
 
 Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 National Technology &
 Engineering Solutions of Sandia, LLC (NTESS).  Under the terms of
@@ -2210,6 +2210,22 @@ class exodus:
         for j in range(assem.entity_count):
             assmbly.entity_list.append(assem.entity_list[j])
         return assmbly
+
+    def get_assemblies(self, object_ids):
+        """
+        reads the assembly parameters and assembly data for n assemblies
+        \param   exoid                   exodus file id
+        \param  *assembly                ex_assembly structure
+        """
+        assemblies = [ex_assembly(id=object_id) for object_id in object_ids]
+        assems = (ex_assembly * len(assemblies))(*assemblies)
+        self.__ex_get_assemblies(assems)
+        assembs = [assembly(assem.name.decode('utf8'), assem.id, ex_entity_type_to_objType(assem.type)) for assem in
+                   assems]
+        for i, a in enumerate(assems):
+            for j in range(a.entity_count):
+                assembs[i].entity_list.append(a.entity_list[j])
+        return assembs
 
     def put_assembly(self, assembly):
         """
@@ -5048,6 +5064,16 @@ class exodus:
         assem_struct.entity_list = eptr
         EXODUS_LIB.ex_get_assembly(self.fileId, ctypes.byref(assem_struct))
 
+    # --------------------------------------------------------------------
+
+    def __ex_get_assemblies(self, assem_list):
+        EXODUS_LIB.ex_get_assemblies(self.fileId, assem_list)
+        for assem_struct in assem_list:
+            ptr = ctypes.create_string_buffer(MAX_NAME_LENGTH + 1)
+            assem_struct.name = ctypes.cast(ptr, ctypes.c_char_p)
+            eptr = (ctypes.c_longlong * assem_struct.entity_count)()
+            assem_struct.entity_list = eptr
+        EXODUS_LIB.ex_get_assemblies(self.fileId, assem_list)
 
     # --------------------------------------------------------------------
 

--- a/packages/seacas/scripts/tests/test_exodus3.py
+++ b/packages/seacas/scripts/tests/test_exodus3.py
@@ -1,3 +1,12 @@
+"""
+Copyright(C) 1999-2021 National Technology & Engineering Solutions
+of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+NTESS, the U.S. Government retains certain rights in this software.
+
+See packages/seacas/LICENSE for details
+
+"""
+
 import unittest
 import sys
 import os
@@ -50,6 +59,27 @@ class MyTestCase(unittest.TestCase):
         root = exo.assembly(name='Root', type='assembly', id=100)
         root.entity_list = [100, 200, 300, 400]
         self.assertEqual(str(root), str(assemblies[0]))
+
+    def test_get_assemblies(self):
+        temp_exofile = exo.exodus("test-assembly.exo", mode='r')
+        assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
+        assemblies = temp_exofile.get_assemblies(assembly_ids)
+        expected = [exo.assembly(name='Root', type='assembly', id=100),
+                    exo.assembly(name='Child2', type='element block', id=200),
+                    exo.assembly(name='Child3', type='element block', id=300),
+                    exo.assembly(name='Child4', type='element block', id=400),
+                    exo.assembly(name='NewAssembly', type='assembly', id=222),
+                    exo.assembly(name='FromPython', type='assembly', id=333)]
+        for i, x in enumerate(expected):
+            entity_lists = [[100, 200, 300, 400],
+                            [10, 11, 12, 13],
+                            [14, 15, 16],
+                            [10, 16],
+                            [100, 200, 300, 400],
+                            [100, 222]]
+            x.entity_list = entity_lists[i]
+        self.maxDiff=None
+        self.assertEqual(str(expected), str(assemblies))
 
     def test_add_assembly(self):
         new = exo.assembly(name='Unit_test', type='EX_ASSEMBLY', id=444)


### PR DESCRIPTION
Allow for the ex_get_assemblies function to be called from
the exodus python interface. Includes a unittest as well.
Updated some Copyrights.