### PR TITLE
Capture arrays by reference rather than value

### DIFF
--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C
@@ -2273,7 +2273,7 @@ namespace Iocgns {
 
         // ========================================================================
         // Repetitive code for each coordinate direction; use a lambda to consolidate...
-        auto coord_lambda = [this, base, zone, &coord, rmin, rmax, phys_dimension, num_to_get,
+        auto coord_lambda = [this, base, zone, &coord, &rmin, &rmax, phys_dimension, num_to_get,
                              &rdata](const char *ord_name, int ordinate) {
           CGCHECKM(cg_coord_read(get_file_pointer(), base, zone, ord_name, CG_RealDouble, rmin,
                                  rmax, coord.data()));


### PR DESCRIPTION
MSVC 2015 doesn't compile when capturing stack-allocated arrays by
value in a lambda expression.