### PR TITLE
Ioss: Missing strncasecmp define

### DIFF
--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_Utils.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_Utils.C
@@ -58,6 +58,9 @@
   }
 
 #ifdef _WIN32
+#ifdef _MSC_VER
+#define strncasecmp strnicmp
+#endif
 char *strcasestr(char *haystack, const char *needle)
 {
   char *c;


### PR DESCRIPTION
seems necessary for some msvc version