### PR TITLE
EXODUS.py Cleaning and Testing

### DIFF
--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -2189,7 +2189,7 @@ class exodus:
         """
         names = self.get_variable_names(objType)
         var_id = names.index(name) + 1
-        numVals = 0;
+        numVals = 0
         if objType == 'EX_NODAL':
             numVals = self.num_nodes()
         elif objType == 'EX_ELEM_BLOCK':
@@ -2232,7 +2232,7 @@ class exodus:
         """
         names = self.get_variable_names(objType)
         var_id = names.index(name) + 1
-        numVals = 0;
+        numVals = 0
         if objType == 'EX_NODAL':
             numVals = self.num_nodes()
         elif objType == 'EX_ELEM_BLOCK':
@@ -5232,7 +5232,7 @@ class exodus:
 
                 attributes[att[i].name.decode('utf8')] = tmp_att
 
-        return attributes;
+        return attributes
 
     # --------------------------------------------------------------------
 

--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -1,5 +1,5 @@
 """
-exodus.py v 1.20.8 (seacas-py3) is a python wrapper of some of the exodus library
+exodus.py v 1.20.9 (seacas-py3) is a python wrapper of some of the exodus library
 (Python 3 Version)
 
 Exodus is a common database for multiple application codes (mesh
@@ -70,10 +70,10 @@ from enum import Enum
 
 EXODUS_PY_COPYRIGHT_AND_LICENSE = __doc__
 
-EXODUS_PY_VERSION = "1.20.8 (seacas-py3)"
+EXODUS_PY_VERSION = "1.20.9 (seacas-py3)"
 
 EXODUS_PY_COPYRIGHT = """
-You are using exodus.py v 1.20.8 (seacas-py3), a python wrapper of some of the exodus library.
+You are using exodus.py v 1.20.9 (seacas-py3), a python wrapper of some of the exodus library.
 
 Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 National Technology &
 Engineering Solutions of Sandia, LLC (NTESS).  Under the terms of
@@ -116,18 +116,19 @@ def getExodusVersion():
     """
     version_major = -1
     version_minor = -1
-    for line in open(ACCESS + "/include/exodusII.h"):
-        fields = line.split()
-        if (len(fields) == 3 and
-                fields[0] == '#define' and
-                fields[1] == 'EXODUS_VERSION_MAJOR'):
-            version_major = int(fields[2])
-        if (len(fields) == 3 and
-                fields[0] == '#define' and
-                fields[1] == 'EXODUS_VERSION_MINOR'):
-            version_minor = int(fields[2])
-        if (version_major > 0 and version_minor >= 0):
-           return 100 * version_major + version_minor
+    with open(ACCESS + "/include/exodusII.h") as header_file:
+        for line in header_file:
+            fields = line.split()
+            if (len(fields) == 3 and
+                    fields[0] == '#define' and
+                    fields[1] == 'EXODUS_VERSION_MAJOR'):
+                version_major = int(fields[2])
+            if (len(fields) == 3 and
+                    fields[0] == '#define' and
+                    fields[1] == 'EXODUS_VERSION_MINOR'):
+                version_minor = int(fields[2])
+            if (version_major > 0 and version_minor >= 0):
+               return 100 * version_major + version_minor
     return 0
 
 

--- a/packages/seacas/scripts/tests/test_exodus3.py
+++ b/packages/seacas/scripts/tests/test_exodus3.py
@@ -86,7 +86,7 @@ class MyTestCase(unittest.TestCase):
                             [100, 200, 300, 400],
                             [100, 222]]
             x.entity_list = entity_lists[i]
-        self.maxDiff=None
+        self.maxDiff = None
         self.assertEqual(str(expected), str(assemblies))
 
     def test_put_assembly(self):
@@ -151,7 +151,6 @@ class MyTestCase(unittest.TestCase):
         values = temp_exofile.get_reduction_variable_values('EX_ASSEMBLY', assemblies[5].id, 1)
         self.assertListEqual([0.00, 0.00, 0.00, 0.00], list(values))
 
-
     def test_put_assemblies(self):
         new = exo.assembly(name='Unit_test', type='EX_ASSEMBLY', id=444)
         new.entity_list = [100, 222]
@@ -164,7 +163,6 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(16, assemblies[6].type)
         self.assertEqual(new.id, assemblies[6].id)
         self.assertEqual(new.entity_list, assemblies[6].entity_list)
-
 
     def test_put_assemblies_multiple_assemblies(self):
         new = exo.assembly(name='Unit_test1', type='EX_ASSEMBLY', id=444)


### PR DESCRIPTION
Clean up some spacing and remove semi-colons.
Fix a small memory leak in _getExodusVersion().
Add some tests for exodus3.py.