### PR TITLE
gcc 4.8.5: use non-const iterators for std::vector::erase()

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Compare.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Compare.C
@@ -851,7 +851,7 @@ namespace {
 
     if (!in_blocks_1.empty()) {
       for (const auto &in_block_1 : in_blocks_1) {
-        typename std::vector<T *>::const_iterator it;
+        typename std::vector<T *>::iterator it;
         for (it = in_blocks_2.begin(); it != in_blocks_2.end(); it++) {
           if (*(*it) == *in_block_1) {
             break;
@@ -967,7 +967,7 @@ namespace {
 
     if (!in_sets_1.empty()) {
       for (const auto &in_set_1 : in_sets_1) {
-        typename std::vector<T *>::const_iterator it;
+        typename std::vector<T *>::iterator it;
         for (it = in_sets_2.begin(); it != in_sets_2.end(); it++) {
           if (*(*it) == *in_set_1) {
             break;
@@ -1072,7 +1072,7 @@ namespace {
 
     if (!in_css_1.empty()) {
       for (const auto &in_cs_1 : in_css_1) {
-        typename std::vector<Ioss::CommSet *>::const_iterator it;
+        typename std::vector<Ioss::CommSet *>::iterator it;
         for (it = in_css_2.begin(); it != in_css_2.end(); it++) {
           if (*(*it) == *in_cs_1) {
             break;
@@ -1114,7 +1114,7 @@ namespace {
 
     if (!in_cfs_1.empty()) {
       for (const auto &in_cf_1 : in_cfs_1) {
-        typename std::vector<Ioss::CoordinateFrame>::const_iterator it;
+        typename std::vector<Ioss::CoordinateFrame>::iterator it;
         for (it = in_cfs_2.begin(); it != in_cfs_2.end(); it++) {
           if ((*it) == in_cf_1) {
             break;


### PR DESCRIPTION
Workaround gcc 4.8.5's lack of support for const iterators
as arguments to std::vector::erase().