### PR TITLE
SEACAS: Move logic to disable SEACAS subpackages that depend on Fortran (trilinos/Trilinos#3346)

### DIFF
--- a/cmake/RepositoryDependenciesSetup.cmake
+++ b/cmake/RepositoryDependenciesSetup.cmake
@@ -1,0 +1,6 @@
+# Special logic to disable SEACAS subpackages depending on Fortran enabled or not
+
+if (SEACAS_SOURCE_DIR)
+  include("${SEACAS_SOURCE_DIR}/cmake/SeacasDisableSubpackagesDependingOnFortran.cmake")
+  seacas_disable_subpackages_depending_on_fortran()
+endif()

--- a/packages/seacas/CMakeLists.txt
+++ b/packages/seacas/CMakeLists.txt
@@ -63,47 +63,6 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   OFF
   )
 
-function(disable_if_no_fortran package)
-IF (NOT ${PROJECT_NAME}_ENABLE_Fortran)
-  IF (${PROJECT_NAME}_ENABLE_SEACAS${package})
-    MESSAGE("-- "
-      "WARNING: Setting ${PROJECT_NAME}_ENABLE_SEACAS${package}=OFF"
-      " even though it was set to ${${PROJECT_NAME}_ENABLE_SEACAS${package}}"
-      " because ${PROJECT_NAME}_ENABLE_Fortran=OFF!"
-      )
-  ELSEIF("${${PROJECT_NAME}_ENABLE_SEACAS${package}}" STREQUAL "")
-     MESSAGE("-- "
-      "NOTE: Setting ${PROJECT_NAME}_ENABLE_SEACAS${package}=OFF"
-      " because ${PROJECT_NAME}_ENABLE_Fortran=OFF!"
-       )
-  ENDIF()
-  SET(${PROJECT_NAME}_ENABLE_SEACAS${package} OFF PARENT_SCOPE)
-ENDIF()
-endfunction()
-
-disable_if_no_fortran(Mapvarlib)
-disable_if_no_fortran(Exodus_for)
-disable_if_no_fortran(ExoIIv2for32)
-disable_if_no_fortran(Supes)
-disable_if_no_fortran(Suplib)
-disable_if_no_fortran(PLT)
-disable_if_no_fortran(Blot)
-disable_if_no_fortran(Fastq)
-disable_if_no_fortran(SVDI)
-disable_if_no_fortran(Algebra)
-disable_if_no_fortran(Exotxt)
-disable_if_no_fortran(Gjoin)
-disable_if_no_fortran(Gen3D)
-disable_if_no_fortran(Genshell)
-disable_if_no_fortran(Grepos)
-disable_if_no_fortran(Explore)
-disable_if_no_fortran(Mapvar)
-disable_if_no_fortran(Mapvar-kd)
-disable_if_no_fortran(Numbers)
-disable_if_no_fortran(Txtexo)
-disable_if_no_fortran(Ex2ex1v2)
-disable_if_no_fortran(Ex1ex2v2)
-
 IF (NOT ${PROJECT_NAME}_ENABLE_Fortran)
 # For some reason, this variable is undefined if fortran is disabled and it causes a cmake error.
 # define it to a nonsense variable to avoid error.

--- a/packages/seacas/cmake/SeacasDisableSubpackagesDependingOnFortran.cmake
+++ b/packages/seacas/cmake/SeacasDisableSubpackagesDependingOnFortran.cmake
@@ -1,0 +1,45 @@
+
+macro(seacas_disable_subpackages_depending_on_fortran)
+  if (NOT ${PROJECT_NAME}_ENABLE_Fortran)
+    seacas_disable_subpackage_since_no_fortran(Mapvarlib)
+    seacas_disable_subpackage_since_no_fortran(Exodus_for)
+    seacas_disable_subpackage_since_no_fortran(ExoIIv2for32)
+    seacas_disable_subpackage_since_no_fortran(Supes)
+    seacas_disable_subpackage_since_no_fortran(Suplib)
+    seacas_disable_subpackage_since_no_fortran(PLT)
+    seacas_disable_subpackage_since_no_fortran(Blot)
+    seacas_disable_subpackage_since_no_fortran(Fastq)
+    seacas_disable_subpackage_since_no_fortran(SVDI)
+    seacas_disable_subpackage_since_no_fortran(Algebra)
+    seacas_disable_subpackage_since_no_fortran(Exotxt)
+    seacas_disable_subpackage_since_no_fortran(Gjoin)
+    seacas_disable_subpackage_since_no_fortran(Gen3D)
+    seacas_disable_subpackage_since_no_fortran(Genshell)
+    seacas_disable_subpackage_since_no_fortran(Grepos)
+    seacas_disable_subpackage_since_no_fortran(Explore)
+    seacas_disable_subpackage_since_no_fortran(Mapvar)
+    seacas_disable_subpackage_since_no_fortran(Mapvar-kd)
+    seacas_disable_subpackage_since_no_fortran(Numbers)
+    seacas_disable_subpackage_since_no_fortran(Txtexo)
+    seacas_disable_subpackage_since_no_fortran(Ex2ex1v2)
+    seacas_disable_subpackage_since_no_fortran(Ex1ex2v2)
+  endif()
+endmacro()
+
+
+macro(seacas_disable_subpackage_since_no_fortran subpackage)
+  if (${PROJECT_NAME}_ENABLE_SEACAS${subpackage})
+    message("-- "
+      "WARNING: Setting ${PROJECT_NAME}_ENABLE_SEACAS${subpackage}=OFF"
+      " even though it was set to ${${PROJECT_NAME}_ENABLE_SEACAS${subpackage}}"
+      " because ${PROJECT_NAME}_ENABLE_Fortran=${${PROJECT_NAME}_ENABLE_Fortran}!"
+      )
+  elseif("${${PROJECT_NAME}_ENABLE_SEACAS${subpackage}}" STREQUAL "")
+     message("-- "
+      "NOTE: Setting ${PROJECT_NAME}_ENABLE_SEACAS${subpackage}=OFF"
+      " because ${PROJECT_NAME}_ENABLE_Fortran=${${PROJECT_NAME}_ENABLE_Fortran}!"
+       )
+  endif()
+  set(${PROJECT_NAME}_ENABLE_SEACAS${subpackage} OFF)
+endmacro()
+


### PR DESCRIPTION
@gsjaardema 

This is an identical PR to the Trilinos PR trilinos/Trilinos#9772 to address trilinos/Trilinos#3346.

This makes sure future snapshots of SEACAS into Trilinos will not overwrite the changes in PR trilinos/Trilinos#9772

## Testing

To test this, believe it or not, I used the same [SEMS Dev Env](https://github.com/trilinos/Trilinos/wiki/SEMS-Dev-Env) and loaded the env with:

```
$ source ~/Trilinos/cmake/load_sems_dev_env.sh

$ module list
Currently Loaded Modulefiles:
  1) sems-env                                     6) sems-gcc/7.2.0                              11) sems-netcdf/4.7.3/parallel
  2) sems-python/2.7.9                            7) sems-openmpi/1.10.1                         12) sems-parmetis/4.0.3/parallel
  3) sems-cmake/3.17.1                            8) sems-boost/1.63.0/base                      13) sems-scotch/6.0.3/nopthread_64bit_parallel
  4) sems-ninja_fortran/1.8.2                     9) sems-zlib/1.2.8/base                        14) sems-superlu/4.3/base
  5) sems-git/2.10.1                             10) sems-hdf5/1.10.6/parallel
```

and with the configuration files:

```
$ cat do-configure.base
#!/bin/bash

if [ -e CMakeCache.txt ] ; then
  echo "Removing CMakeCache.txt" 
  rm CMakeCache.txt
fi

if [ -d CMakeFiles ] ; then
  echo "Removing CMakeFiles/" 
  rm -r CMakeFiles
fi

cmake \
-GNinja \
-DSEACASProj_CONFIGURE_OPTIONS_FILE=$HOME/Trilinos.base/Trilinos/cmake/std/sems/SEMSDevEnv.cmake \
-DBUILD_SHARED_LIBS=ON \
-DCMAKE_BUILD_TYPE=RELEASE \
-DTPL_ENABLE_MPI=ON \
-DSEACASProj_ENABLE_TESTS=ON \
-DCMAKE_INSTALL_PREFIX=install \
"$@" \
~/Trilinos.base/Trilinos/seacas

$ cat do-configure
#!/bin/bash
./do-configure.base \
-DSEACASProj_ENABLE_Fortran=OFF \
-DSEACASProj_ENABLE_SEACAS=ON \
"$@"
```

I configured, built, and installed SEACAS through Trilinos with:

```
$ ./do-confiugre

$ make

$ ctest -j16
...
100% tests passed, 0 tests failed out of 27

Subproject Time Summary:
SEACAS    =  59.73 sec*proc (27 tests)

Total Test time (real) =   8.70 sec
```

The configure output showed:

```
...
Processing Project, Repository, and Package dependency files and building internal dependencies graph ...

-- NOTE: Setting SEACASProj_ENABLE_SEACASMapvarlib=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASExodus_for=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASExoIIv2for32=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASSupes=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASSuplib=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASPLT=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASBlot=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASFastq=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASSVDI=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASAlgebra=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASExotxt=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASGjoin=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASGen3D=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASGenshell=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASGrepos=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASExplore=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASMapvar=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASMapvar-kd=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASNumbers=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASTxtexo=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASEx2ex1v2=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- NOTE: Setting SEACASProj_ENABLE_SEACASEx1ex2v2=OFF because SEACASProj_ENABLE_Fortran=OFF!
-- SEACASProj_NUM_SE_PACKAGES='47'
-- Tentatively enabling TPL 'DLlib'

...

Final set of enabled packages:  Zoltan SEACAS 2

Final set of enabled SE packages:  Zoltan SEACASExodus SEACASNemesis SEACASIoss SEACASChaco SEACASAprepro_lib SEACASSuplibC SEACASSuplibCpp SEACASAprepro SEACASConjoin SEACASEjoin SEACASEpu SEACASCpup SEACASExodiff SEACASExo_format SEACASNas2exo SEACASNemslice SEACASNemspread SEACAS 19

...

Final set of enabled TPLs:  Netcdf DLlib 2

...

Processing enabled package: SEACAS (Exodus, Nemesis, Ioss, Chaco, Aprepro_lib, SuplibC, SuplibCpp, Aprepro, Conjoin, Ejoin, Epu, Cpup, Exodiff, Exo_format, Nas2exo, Nemslice, Nemspread, Tests, Examples)
-- WARNING: Setting CMAKE_Fortran_LINK_EXECUTABLE to a random value to avoid CMake error
-- Looking for sys/resource.h
-- Looking for sys/resource.h - found
-- A Python-2 version of exodus.py and exomerge.py will be installed.
```

Then I tested this installed `SEACASConfig.cmake` with a simple CMake project `use_seacas` with the `CMakeLists.txt` file:

```
cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
project(UseSEACAS)
set(CMAKE_CXX_EXTENSIONS OFF)
find_package(SEACAS)
message("SEACAS_LIBRARIES = '${SEACAS_LIBRARIES}'")
```

and I configured it with:

```
$ mkdir use_seacas_build

$ cd use_seacas_build/

$ cmake -D CMAKE_PREFIX_PATH=${PWD}/../install ../use_seacas
...
SEACAS_LIBRARIES = 'suplib_cpp;suplib_c;aprepro_lib;chaco;io_info_lib;Ionit;Iotr;Iohb;Iogs;Iogn;Iovs;Ioex;Ioss;nemesis;exodus;zoltan'
...
```
