### PR TITLE
Ioex_IOFactory: remove zlib.h usage

### DIFF
--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_IOFactory.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_IOFactory.C
@@ -16,7 +16,6 @@
 #include <exodusII.h>
 #include <fmt/ostream.h>
 #include <string> // for string
-#include <zlib.h>
 
 #include "Ioss_CodeTypes.h" // for MPI_Comm
 #include "Ioss_DBUsage.h"   // for DatabaseUsage
@@ -116,10 +115,6 @@ namespace Ioex {
     fmt::print(config, "\tZoltan Library is Available for Parallel Decomposition.\n\n");
 #else
     fmt::print(config, "\tZoltan Library is NOT Available for Parallel Decomposition.\n\n");
-#endif
-#if defined(ZLIBNG_VERSION)
-    fmt::print(config, "\tZlib-NG library version {} being used for accelerated compression.\n\n",
-               ZLIBNG_VERSION);
 #endif
     return config.str();
   }


### PR DESCRIPTION
This isn't actually used anywhere else in ioss, so its version isn't
very useful.