### PR TITLE
EXODUS.PY: Make sure it works when installed with environment variables.

### DIFF
--- a/packages/seacas/scripts/CMakeLists.txt
+++ b/packages/seacas/scripts/CMakeLists.txt
@@ -109,6 +109,11 @@ IF (${PROJECT_NAME}_ENABLE_SEACASExodus)
 		${CMAKE_CURRENT_BINARY_DIR}/tests/test_exodus3.py
 		@ONLY
 		)
+  CONFIGURE_FILE(
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/test-assembly.exo
+		${CMAKE_CURRENT_BINARY_DIR}/tests/test-assembly.exo
+		COPYONLY
+		)
 
       INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/exodus2.py DESTINATION lib)
       INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/exodus3.py DESTINATION lib)


### PR DESCRIPTION
Make sure exodus.py tests work without the ACCESS and INSTALL_PATH
environment variables set at install time.