### PR TITLE
Ioss_CodeTypes: avoid defining ssize_t

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_CodeTypes.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_CodeTypes.h
@@ -20,10 +20,13 @@
 
 #if defined(__IOSS_WINDOWS__)
 #ifdef _WIN64
-#define ssize_t __int64
+#define ioss_ssize_t __int64
 #else
-#define ssize_t long
+#define ioss_ssize_t long
 #endif
+#else
+#include <sys/types.h>
+#define ioss_ssize_t ssize_t
 #endif
 
 namespace Ioss {

--- a/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.C
@@ -1078,8 +1078,8 @@ namespace Ioss {
       std::vector<double> coordinates;
       Ioss::NodeBlock    *nb = get_region()->get_node_blocks()[0];
       nb->get_field_data("mesh_model_coordinates", coordinates);
-      ssize_t nnode = nb->entity_count();
-      ssize_t ndim  = nb->get_property("component_degree").get_int();
+      ioss_ssize_t nnode = nb->entity_count();
+      ioss_ssize_t ndim  = nb->get_property("component_degree").get_int();
 
       const Ioss::ElementBlockContainer &element_blocks = get_region()->get_element_blocks();
       size_t                             nblock         = element_blocks.size();
@@ -1126,8 +1126,8 @@ namespace Ioss {
   {
     std::vector<double> coordinates;
     nb->get_field_data("mesh_model_coordinates", coordinates);
-    ssize_t nnode = nb->entity_count();
-    ssize_t ndim  = nb->get_property("component_degree").get_int();
+    ioss_ssize_t nnode = nb->entity_count();
+    ioss_ssize_t ndim  = nb->get_property("component_degree").get_int();
 
     double xmin, ymin, zmin, xmax, ymax, zmax;
     calc_bounding_box(ndim, nnode, coordinates, xmin, ymin, zmin, xmax, ymax, zmax);
@@ -1150,7 +1150,7 @@ namespace Ioss {
 
   AxisAlignedBoundingBox DatabaseIO::get_bounding_box(const Ioss::StructuredBlock *sb) const
   {
-    ssize_t ndim = sb->get_property("component_degree").get_int();
+    ioss_ssize_t ndim = sb->get_property("component_degree").get_int();
 
     std::pair<double, double> xx;
     std::pair<double, double> yy;

--- a/packages/seacas/libraries/ioss/src/Ioss_Map.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Map.C
@@ -4,6 +4,7 @@
 //
 // See packages/seacas/LICENSE for details
 
+#include <Ioss_CodeTypes.h> // for ioss_ssize_t
 #include <Ioss_Field.h> // for Field, etc
 #include <Ioss_Map.h>
 #include <Ioss_SmartAssert.h>
@@ -15,7 +16,6 @@
 #include <numeric>
 #include <sstream>
 #include <string>
-#include <sys/types.h> // for ssize_t
 #include <vector>      // for vector, vector<>::iterator, etc
 
 namespace {
@@ -364,9 +364,9 @@ size_t Ioss::Map::map_field_to_db_scalar_order(T *variables, std::vector<double>
     size_t k = offset;
     for (size_t j = begin_offset; j < count * stride; j += stride) {
       // Map to storage location.
-      ssize_t where = m_reorder[k++] - offset;
+      ioss_ssize_t where = m_reorder[k++] - offset;
       if (where >= 0) {
-        SMART_ASSERT(where < (ssize_t)count)(where)(count);
+        SMART_ASSERT(where < (ioss_ssize_t)count)(where)(count);
         db_var[where] = variables[j];
         num_out++;
       }

--- a/packages/seacas/libraries/ioss/src/Ioss_Region.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Region.C
@@ -8,6 +8,7 @@
 
 #include <Ioss_Assembly.h>
 #include <Ioss_Blob.h>
+#include <Ioss_CodeTypes.h>
 #include <Ioss_CommSet.h>
 #include <Ioss_CoordinateFrame.h>
 #include <Ioss_DBUsage.h>
@@ -1520,8 +1521,8 @@ namespace Ioss {
       if (old_ge != nullptr && ge != old_ge) {
         if (!((old_ge->type() == SIDEBLOCK && ge->type() == SIDESET) ||
               (ge->type() == SIDEBLOCK && old_ge->type() == SIDESET))) {
-          ssize_t            old_id = old_ge->get_optional_property(id_str(), -1);
-          ssize_t            new_id = ge->get_optional_property(id_str(), -1);
+          ioss_ssize_t       old_id = old_ge->get_optional_property(id_str(), -1);
+          ioss_ssize_t       new_id = ge->get_optional_property(id_str(), -1);
           std::ostringstream errmsg;
           fmt::print(errmsg,
                      "\n\nERROR: Duplicate names detected.\n"

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C
@@ -2384,7 +2384,7 @@ namespace Iocgns {
     int zone = Iocgns::Utils::get_db_zone(sb);
     int sect = sb->get_property("section").get_int();
 
-    ssize_t num_to_get = field.verify(data_size);
+    ioss_ssize_t num_to_get = field.verify(data_size);
     if (num_to_get > 0) {
       int64_t entity_count = sb->entity_count();
       if (num_to_get != entity_count) {
@@ -2479,7 +2479,7 @@ namespace Iocgns {
           if (field.get_type() == Ioss::Field::INT32) {
             int   *idata = reinterpret_cast<int *>(data);
             size_t j     = 0;
-            for (ssize_t i = 0; i < num_to_get; i++) {
+            for (ioss_ssize_t i = 0; i < num_to_get; i++) {
               idata[j++] = parent[num_to_get * 0 + i] + offset; // Element
               idata[j++] = parent[num_to_get * 2 + i];
               SMART_ASSERT(parent[num_to_get * 1 + i] == 0);
@@ -2491,7 +2491,7 @@ namespace Iocgns {
           else {
             auto  *idata = reinterpret_cast<int64_t *>(data);
             size_t j     = 0;
-            for (ssize_t i = 0; i < num_to_get; i++) {
+            for (ioss_ssize_t i = 0; i < num_to_get; i++) {
               idata[j++] = parent[num_to_get * 0 + i] + offset; // Element
               idata[j++] = parent[num_to_get * 2 + i];
               SMART_ASSERT(parent[num_to_get * 1 + i] == 0);
@@ -3080,7 +3080,7 @@ namespace Iocgns {
 
     int     base       = parent_block->get_property("base").get_int();
     int     zone       = Iocgns::Utils::get_db_zone(parent_block);
-    ssize_t num_to_get = field.verify(data_size);
+    ioss_ssize_t num_to_get = field.verify(data_size);
 
     if (num_to_get == 0) {
       return num_to_get;
@@ -3130,7 +3130,7 @@ namespace Iocgns {
         if (field.get_type() == Ioss::Field::INT32) {
           int   *idata = reinterpret_cast<int *>(data);
           size_t j     = 0;
-          for (ssize_t i = 0; i < num_to_get; i++) {
+          for (ioss_ssize_t i = 0; i < num_to_get; i++) {
             cgsize_t element           = elemMap.global_to_local(idata[j++]) - offset;
             parent[num_to_get * 0 + i] = element;
             parent[num_to_get * 2 + i] = idata[j++]; // side
@@ -3141,7 +3141,7 @@ namespace Iocgns {
         else {
           auto  *idata = reinterpret_cast<int64_t *>(data);
           size_t j     = 0;
-          for (ssize_t i = 0; i < num_to_get; i++) {
+          for (ioss_ssize_t i = 0; i < num_to_get; i++) {
             cgsize_t element           = elemMap.global_to_local(idata[j++]) - offset;
             parent[num_to_get * 0 + i] = element; // Element
             parent[num_to_get * 2 + i] = idata[j++];

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_DecompositionData.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_DecompositionData.C
@@ -753,8 +753,8 @@ namespace Iocgns {
       offset += block.file_count();
       size_t b_end = b_start + block.file_count();
 
-      ssize_t overlap      = std::min(b_end, p_end) - std::max(b_start, p_start);
-      overlap              = std::max(overlap, (ssize_t)0);
+      ioss_ssize_t overlap = std::min(b_end, p_end) - std::max(b_start, p_start);
+      overlap              = std::max(overlap, (ioss_ssize_t)0);
       block.fileCount      = overlap;
       size_t element_nodes = block.nodesPerEntity;
       int    zone          = block.zone_;
@@ -778,7 +778,7 @@ namespace Iocgns {
       size_t el          = 0;
       INT    zone_offset = block.zoneNodeOffset;
 
-      for (ssize_t elem = 0; elem < overlap; elem++) {
+      for (ioss_ssize_t elem = 0; elem < overlap; elem++) {
         decomposition.m_pointer.push_back(decomposition.m_adjacency.size());
         for (size_t k = 0; k < element_nodes; k++) {
           INT node = connectivity[el++] - 1 + zone_offset; // 0-based node

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
@@ -68,10 +68,10 @@ namespace {
 #endif
   }
 
-  void map_local_to_global_implicit(CGNSIntVector &data, ssize_t count,
+  void map_local_to_global_implicit(CGNSIntVector &data, ioss_ssize_t count,
                                     const CGNSIntVector &global_implicit_map)
   {
-    for (ssize_t i = 0; i < count; i++) {
+    for (ioss_ssize_t i = 0; i < count; i++) {
       data[i] = global_implicit_map[data[i] - 1];
     }
   }
@@ -1609,7 +1609,7 @@ namespace Iocgns {
     int         id   = sb->get_property("id").get_int();
     const auto &sset = decomp->m_sideSets[id];
 
-    ssize_t num_to_get = field.verify(data_size);
+    ioss_ssize_t num_to_get = field.verify(data_size);
     if (num_to_get > 0) {
       int64_t entity_count = sb->entity_count();
       if (num_to_get != entity_count) {
@@ -2420,7 +2420,7 @@ namespace Iocgns {
 
     int     base       = parent_block->get_property("base").get_int();
     int     zone       = parent_block->get_property("zone").get_int();
-    ssize_t num_to_get = field.verify(data_size);
+    ioss_ssize_t num_to_get = field.verify(data_size);
 
     Ioss::Field::RoleType role = field.get_role();
 
@@ -2467,7 +2467,7 @@ namespace Iocgns {
         if (field.get_type() == Ioss::Field::INT32) {
           int   *idata = reinterpret_cast<int *>(data);
           size_t j     = 0;
-          for (ssize_t i = 0; i < num_to_get; i++) {
+          for (ioss_ssize_t i = 0; i < num_to_get; i++) {
             parent[num_to_get * 0 + i] = elemMap.global_to_local(idata[j++]); // Element
             parent[num_to_get * 2 + i] = idata[j++];
           }
@@ -2475,7 +2475,7 @@ namespace Iocgns {
         else {
           auto  *idata = reinterpret_cast<int64_t *>(data);
           size_t j     = 0;
-          for (ssize_t i = 0; i < num_to_get; i++) {
+          for (ioss_ssize_t i = 0; i < num_to_get; i++) {
             parent[num_to_get * 0 + i] = elemMap.global_to_local(idata[j++]); // Element
             parent[num_to_get * 2 + i] = idata[j++];
           }

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_Utils.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_Utils.C
@@ -1731,8 +1731,8 @@ size_t Iocgns::Utils::resolve_nodes(Ioss::Region &region, int my_processor, bool
     num_total_cell_nodes += node_count;
   }
 
-  ssize_t              ss_max = std::numeric_limits<ssize_t>::max();
-  std::vector<ssize_t> cell_node_map(num_total_cell_nodes, ss_max);
+  ioss_ssize_t              ss_max = std::numeric_limits<ioss_ssize_t>::max();
+  std::vector<ioss_ssize_t> cell_node_map(num_total_cell_nodes, ss_max);
 
   // Each cell_node location in the cell_node_map is currently initialized to ss_max.
   // Iterate each block and then each blocks non-intra-block (i.e., not
@@ -1763,8 +1763,8 @@ size_t Iocgns::Utils::resolve_nodes(Ioss::Region &region, int my_processor, bool
               // the owner (unless it is already owned by another
               // block)
 
-              ssize_t owner_global_offset = owner_block->get_global_node_offset(owner_index);
-              ssize_t donor_global_offset = donor_block->get_global_node_offset(donor_index);
+              ioss_ssize_t owner_global_offset = owner_block->get_global_node_offset(owner_index);
+              ioss_ssize_t donor_global_offset = donor_block->get_global_node_offset(donor_index);
 
               if (owner_global_offset > donor_global_offset) {
                 if (is_parallel && (zgc.m_donorProcessor != my_processor)) {
@@ -1775,7 +1775,7 @@ size_t Iocgns::Utils::resolve_nodes(Ioss::Region &region, int my_processor, bool
                 }
                 else if (!is_parallel || (zgc.m_ownerProcessor != my_processor)) {
                   size_t  owner_local_offset = owner_block->get_local_node_offset(owner_index);
-                  ssize_t donor_local_offset = donor_block->get_local_node_offset(donor_index);
+                  ioss_ssize_t donor_local_offset = donor_block->get_local_node_offset(donor_index);
 
                   if (cell_node_map[owner_local_offset] == ss_max) {
                     cell_node_map[owner_local_offset] = donor_local_offset;
@@ -1868,11 +1868,11 @@ Iocgns::Utils::resolve_processor_shared_nodes(Ioss::Region &region, int my_proce
               // should refer to the same node.
 
               if (my_processor == zgc.m_ownerProcessor) {
-                ssize_t owner_offset = owner_block->get_block_local_node_offset(owner_index);
+                ioss_ssize_t owner_offset = owner_block->get_block_local_node_offset(owner_index);
                 shared_nodes[owner_zone].emplace_back(owner_offset, zgc.m_donorProcessor);
               }
               else if (my_processor == zgc.m_donorProcessor) {
-                ssize_t donor_offset = donor_block->get_block_local_node_offset(donor_index);
+                ioss_ssize_t donor_offset = donor_block->get_block_local_node_offset(donor_index);
                 shared_nodes[donor_zone].emplace_back(donor_offset, zgc.m_ownerProcessor);
               }
             }

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_DatabaseIO.C
@@ -2979,14 +2979,14 @@ int64_t DatabaseIO::get_field_internal(const Ioss::CommSet *cs, const Ioss::Fiel
             if (field.get_name() == "entity_processor") {
               const Ioss::MapContainer &map = get_map(EX_ELEM_BLOCK).map();
 
-              for (ssize_t i = 0; i < entity_count; i++) {
+              for (ioss_ssize_t i = 0; i < entity_count; i++) {
                 entity_proc[j++] = map[ents[i]];
                 entity_proc[j++] = sids[i];
                 entity_proc[j++] = pros[i];
               }
             }
             else { // "entity_processor_raw"
-              for (ssize_t i = 0; i < entity_count; i++) {
+              for (ioss_ssize_t i = 0; i < entity_count; i++) {
                 entity_proc[j++] = ents[i];
                 entity_proc[j++] = sids[i];
                 entity_proc[j++] = pros[i];
@@ -3003,14 +3003,14 @@ int64_t DatabaseIO::get_field_internal(const Ioss::CommSet *cs, const Ioss::Fiel
             if (field.get_name() == "entity_processor") {
               const Ioss::MapContainer &map = get_map(EX_ELEM_BLOCK).map();
 
-              for (ssize_t i = 0; i < entity_count; i++) {
+              for (ioss_ssize_t i = 0; i < entity_count; i++) {
                 entity_proc[j++] = map[ents[i]];
                 entity_proc[j++] = sids[i];
                 entity_proc[j++] = pros[i];
               }
             }
             else { // "entity_processor_raw"
-              for (ssize_t i = 0; i < entity_count; i++) {
+              for (ioss_ssize_t i = 0; i < entity_count; i++) {
                 entity_proc[j++] = ents[i];
                 entity_proc[j++] = sids[i];
                 entity_proc[j++] = pros[i];
@@ -3039,7 +3039,7 @@ int64_t DatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const Ioss::Fi
                                        void *data, size_t data_size) const
 {
   Ioss::SerializeIO serializeIO__(this);
-  ssize_t           num_to_get = field.verify(data_size);
+  ioss_ssize_t      num_to_get = field.verify(data_size);
   if (num_to_get > 0) {
 
     int64_t id           = Ioex::get_id(fb, EX_SIDE_SET, &ids_);
@@ -3095,14 +3095,14 @@ int64_t DatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const Ioss::Fi
           if (field.get_type() == Ioss::Field::INTEGER) {
             // Need to convert 'double' to 'int' for Sierra use...
             int *ids = static_cast<int *>(data);
-            for (ssize_t i = 0; i < num_to_get; i++) {
+            for (ioss_ssize_t i = 0; i < num_to_get; i++) {
               ids[i] = static_cast<int>(real_ids[i]);
             }
           }
           else {
             // Need to convert 'double' to 'int' for Sierra use...
             auto *ids = static_cast<int64_t *>(data);
-            for (ssize_t i = 0; i < num_to_get; i++) {
+            for (ioss_ssize_t i = 0; i < num_to_get; i++) {
               ids[i] = static_cast<int64_t>(real_ids[i]);
             }
           }
@@ -3135,7 +3135,7 @@ int64_t DatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const Ioss::Fi
           int    *ids     = static_cast<int *>(data);
           int    *els     = reinterpret_cast<int *>(element_side.data());
           size_t  idx     = 0;
-          for (ssize_t iel = 0; iel < 2 * entity_count; iel += 2) {
+          for (ioss_ssize_t iel = 0; iel < 2 * entity_count; iel += 2) {
             int64_t new_id = static_cast<int64_t>(10) * els[iel] + els[iel + 1];
             if (new_id > int_max) {
               std::ostringstream errmsg;
@@ -3154,7 +3154,7 @@ int64_t DatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const Ioss::Fi
           auto  *ids = static_cast<int64_t *>(data);
           auto  *els = reinterpret_cast<int64_t *>(element_side.data());
           size_t idx = 0;
-          for (ssize_t iel = 0; iel < 2 * entity_count; iel += 2) {
+          for (ioss_ssize_t iel = 0; iel < 2 * entity_count; iel += 2) {
             int64_t new_id = 10 * els[iel] + els[iel + 1];
             ids[idx++]     = new_id;
           }
@@ -3194,12 +3194,12 @@ int64_t DatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const Ioss::Fi
         }
 
         if (number_sides == entity_count) {
-          ssize_t index = 0;
+          ioss_ssize_t index = 0;
           if (int_byte_size_api() == 4) {
             auto *element_side = static_cast<int *>(data);
             auto *element32    = reinterpret_cast<int *>(element.data());
             auto *sides32      = reinterpret_cast<int *>(sides.data());
-            for (ssize_t iel = 0; iel < entity_count; iel++) {
+            for (ioss_ssize_t iel = 0; iel < entity_count; iel++) {
               if (do_map) {
                 element_side[index++] = map[element32[iel]];
               }
@@ -3213,7 +3213,7 @@ int64_t DatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const Ioss::Fi
             auto *element_side = static_cast<int64_t *>(data);
             auto *element64    = reinterpret_cast<int64_t *>(element.data());
             auto *sides64      = reinterpret_cast<int64_t *>(sides.data());
-            for (ssize_t iel = 0; iel < entity_count; iel++) {
+            for (ioss_ssize_t iel = 0; iel < entity_count; iel++) {
               if (do_map) {
                 element_side[index++] = map[element64[iel]];
               }
@@ -3231,7 +3231,7 @@ int64_t DatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const Ioss::Fi
                                                       element.data(), sides.data(), number_sides,
                                                       get_region());
 
-          ssize_t index = 0;
+          ioss_ssize_t index = 0;
           if (int_byte_size_api() == 4) {
             auto *element_side = static_cast<int *>(data);
             auto *element32    = reinterpret_cast<int *>(element.data());
@@ -3340,8 +3340,8 @@ int64_t DatabaseIO::write_attribute_field(ex_entity_type type, const Ioss::Field
                                           const Ioss::GroupingEntity *ge, void *data) const
 {
   std::string att_name   = ge->name() + SEP() + field.get_name();
-  ssize_t     num_entity = ge->entity_count();
-  ssize_t     fld_offset = field.get_index();
+  ioss_ssize_t     num_entity = ge->entity_count();
+  ioss_ssize_t     fld_offset = field.get_index();
 
   int64_t id              = Ioex::get_id(ge, type, &ids_);
   int     attribute_count = ge->get_property("attribute_count").get_int();
@@ -3452,7 +3452,7 @@ int64_t DatabaseIO::read_attribute_field(ex_entity_type type, const Ioss::Field 
   int64_t id              = Ioex::get_id(ge, type, &ids_);
 
   std::string att_name = ge->name() + SEP() + field.get_name();
-  ssize_t     offset   = field.get_index();
+  ioss_ssize_t     offset   = field.get_index();
   assert(offset - 1 + field.raw_storage()->component_count() <= attribute_count);
   if (offset == 1 && field.raw_storage()->component_count() == attribute_count) {
     // Read all attributes in one big chunk...
@@ -3485,7 +3485,7 @@ int64_t DatabaseIO::read_attribute_field(ex_entity_type type, const Ioss::Field 
         }
 
         size_t k = i;
-        for (ssize_t j = 0; j < num_entity; j++) {
+        for (ioss_ssize_t j = 0; j < num_entity; j++) {
           rdata[k] = local_data[j];
           k += comp_count;
         }
@@ -3728,7 +3728,7 @@ int64_t DatabaseIO::get_side_connectivity_internal(const Ioss::SideBlock *fb, in
   int     nfnodes      = 0;
   int     ieb          = 0;
   size_t  offset       = 0;
-  for (ssize_t iel = 0; iel < number_sides; iel++) {
+  for (ioss_ssize_t iel = 0; iel < number_sides; iel++) {
     if (is_valid_side[iel] == 1) {
 
       int64_t elem_id = element[iel];
@@ -3737,7 +3737,7 @@ int64_t DatabaseIO::get_side_connectivity_internal(const Ioss::SideBlock *fb, in
       block = get_region()->get_element_block(elem_id);
       assert(block != nullptr);
       if (conn_block != block) {
-        ssize_t nelem = block->entity_count();
+        ioss_ssize_t nelem = block->entity_count();
         nelnode       = block->topology()->number_nodes();
         // Used to map element number into position in connectivity array.
         // E.g., element 97 is the (97-offset)th element in this block and
@@ -3866,7 +3866,7 @@ int64_t DatabaseIO::get_side_distributions(const Ioss::SideBlock *fb, int64_t id
       if (value == 0.0) {
         value = 1.0; // Take care of some buggy mesh generators
       }
-      for (ssize_t j = 0; j < my_side_count * nfnodes; j++) {
+      for (ioss_ssize_t j = 0; j < my_side_count * nfnodes; j++) {
         dist_fact[j] = value;
       }
       return 0;
@@ -4688,8 +4688,8 @@ void DatabaseIO::write_entity_transient_field(ex_entity_type type, const Ioss::F
   int step = get_current_state();
   step     = get_database_step(step);
 
-  Ioss::Map *map       = nullptr;
-  ssize_t    eb_offset = 0;
+  Ioss::Map *map         = nullptr;
+  ioss_ssize_t eb_offset = 0;
   if (ge->type() == Ioss::ELEMENTBLOCK) {
     const auto *elb = dynamic_cast<const Ioss::ElementBlock *>(ge);
     Ioss::Utils::check_dynamic_cast(elb);
@@ -4770,8 +4770,8 @@ void DatabaseIO::write_entity_transient_field(ex_entity_type type, const Ioss::F
       // beg_offset = (re_im*i)+complex_comp
       // number_values = count
       // stride = re_im*comp_count
-      ssize_t begin_offset = (re_im * i) + complex_comp;
-      ssize_t stride       = re_im * comp_count;
+      ioss_ssize_t begin_offset = (re_im * i) + complex_comp;
+      ioss_ssize_t stride       = re_im * comp_count;
 
       if (ioss_type == Ioss::Field::REAL || ioss_type == Ioss::Field::COMPLEX) {
         map->map_field_to_db_scalar_order(static_cast<double *>(variables), temp, begin_offset,

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_DecompositionData.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_DecompositionData.C
@@ -485,14 +485,14 @@ namespace Ioex {
     std::vector<INT> entitylist(max_size);
     std::vector<INT> set_entities_read(set_count);
 
-    size_t  offset     = 0;        // What position are we filling in entitylist.
-    ssize_t remain     = max_size; // Amount of space left in entitylist.
-    size_t  ibeg       = 0;
-    size_t  total_read = 0;
+    size_t  offset      = 0;        // What position are we filling in entitylist.
+    ioss_ssize_t remain = max_size; // Amount of space left in entitylist.
+    size_t  ibeg        = 0;
+    size_t  total_read  = 0;
     for (size_t i = 0; i < set_count; i++) {
-      ssize_t entitys_to_read = sets[i].num_entry;
+      ioss_ssize_t entitys_to_read = sets[i].num_entry;
       do {
-        ssize_t to_read = std::min(remain, entitys_to_read);
+        ioss_ssize_t to_read = std::min(remain, entitys_to_read);
         if (m_processor == root) {
 #if IOSS_DEBUG_OUTPUT
           fmt::print(Ioss::DEBUG(), "{} {} reading {} entities from offset {}\n", set_type_name,

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_ParallelDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_ParallelDatabaseIO.C
@@ -2447,8 +2447,8 @@ int64_t ParallelDatabaseIO::get_field_internal(const Ioss::CommSet *cs, const Io
 int64_t ParallelDatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const Ioss::Field &field,
                                                void *data, size_t data_size) const
 {
-  ssize_t num_to_get = field.verify(data_size);
-  int     ierr       = 0;
+  ioss_ssize_t num_to_get = field.verify(data_size);
+  int     ierr            = 0;
 
   int64_t id           = Ioex::get_id(fb, EX_SIDE_SET, &ids_);
   int64_t entity_count = fb->entity_count();
@@ -2491,14 +2491,14 @@ int64_t ParallelDatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const 
         if (field.get_type() == Ioss::Field::INTEGER) {
           // Need to convert 'double' to 'int' for Sierra use...
           int *ids = static_cast<int *>(data);
-          for (ssize_t i = 0; i < num_to_get; i++) {
+          for (ioss_ssize_t i = 0; i < num_to_get; i++) {
             ids[i] = static_cast<int>(real_ids[i]);
           }
         }
         else {
           // Need to convert 'double' to 'int' for Sierra use...
           int64_t *ids = static_cast<int64_t *>(data);
-          for (ssize_t i = 0; i < num_to_get; i++) {
+          for (ioss_ssize_t i = 0; i < num_to_get; i++) {
             ids[i] = static_cast<int64_t>(real_ids[i]);
           }
         }
@@ -2623,7 +2623,7 @@ int64_t ParallelDatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const 
                                                     element.data(), sides.data(), number_sides,
                                                     get_region());
 
-        ssize_t index = 0;
+        ioss_ssize_t index = 0;
         if (int_byte_size_api() == 4) {
           int *element_side = static_cast<int *>(data);
           int *element32    = reinterpret_cast<int *>(element.data());
@@ -2746,17 +2746,17 @@ int64_t ParallelDatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const 
 int64_t ParallelDatabaseIO::write_attribute_field(ex_entity_type type, const Ioss::Field &field,
                                                   const Ioss::GroupingEntity *ge, void *data) const
 {
-  std::string att_name   = ge->name() + SEP() + field.get_name();
-  ssize_t     num_entity = ge->entity_count();
-  ssize_t     offset     = field.get_index();
+  std::string att_name    = ge->name() + SEP() + field.get_name();
+  ioss_ssize_t num_entity = ge->entity_count();
+  ioss_ssize_t offset     = field.get_index();
 
   int64_t id = Ioex::get_id(ge, type, &ids_);
   assert(offset > 0);
   assert(offset - 1 + field.raw_storage()->component_count() <=
          ge->get_property("attribute_count").get_int());
 
-  size_t  proc_offset = ge->get_optional_property("_processor_offset", 0);
-  ssize_t file_count  = ge->get_optional_property("locally_owned_count", num_entity);
+  size_t  proc_offset     = ge->get_optional_property("_processor_offset", 0);
+  ioss_ssize_t file_count = ge->get_optional_property("locally_owned_count", num_entity);
 
   Ioss::Field::BasicType ioss_type = field.get_type();
   assert(ioss_type == Ioss::Field::REAL || ioss_type == Ioss::Field::INTEGER ||
@@ -2852,7 +2852,7 @@ int64_t ParallelDatabaseIO::read_attribute_field(ex_entity_type type, const Ioss
   }
 
   std::string att_name = ge->name() + SEP() + field.get_name();
-  ssize_t     offset   = field.get_index();
+  ioss_ssize_t offset  = field.get_index();
   assert(offset - 1 + field.raw_storage()->component_count() <= attribute_count);
   if (offset == 1 && field.raw_storage()->component_count() == attribute_count) {
     // Read all attributes in one big chunk...
@@ -3152,8 +3152,8 @@ int64_t ParallelDatabaseIO::get_side_connectivity(const Ioss::SideBlock *fb, int
       // ensure we have correct connectivity
       block = get_region()->get_element_block(elem_id);
       if (conn_block != block) {
-        ssize_t nelem = block->entity_count();
-        nelnode       = block->topology()->number_nodes();
+        ioss_ssize_t nelem = block->entity_count();
+        nelnode            = block->topology()->number_nodes();
         // Used to map element number into position in connectivity array.
         // E.g., element 97 is the (97-offset)th element in this block and
         // is stored in array index (97-offset-1).
@@ -3285,7 +3285,7 @@ int64_t ParallelDatabaseIO::get_side_distributions(const Ioss::SideBlock *fb, in
       if (value == 0.0) {
         value = 1.0; // Take care of some buggy mesh generators
       }
-      for (ssize_t j = 0; j < my_side_count * nfnodes; j++) {
+      for (ioss_ssize_t j = 0; j < my_side_count * nfnodes; j++) {
         dist_fact[j] = value;
       }
       return 0;
@@ -4172,8 +4172,8 @@ void ParallelDatabaseIO::write_entity_transient_field(ex_entity_type type, const
   int step = get_current_state();
   step     = get_database_step(step);
 
-  Ioss::Map *map       = nullptr;
-  ssize_t    eb_offset = 0;
+  Ioss::Map *map         = nullptr;
+  ioss_ssize_t eb_offset = 0;
   if (ge->type() == Ioss::ELEMENTBLOCK) {
     const Ioss::ElementBlock *elb = dynamic_cast<const Ioss::ElementBlock *>(ge);
     Ioss::Utils::check_dynamic_cast(elb);
@@ -4230,8 +4230,8 @@ void ParallelDatabaseIO::write_entity_transient_field(ex_entity_type type, const
       // beg_offset = (re_im*i)+complex_comp
       // number_values = count
       // stride = re_im*comp_count
-      ssize_t begin_offset = (re_im * i) + complex_comp;
-      ssize_t stride       = re_im * comp_count;
+      ioss_ssize_t begin_offset = (re_im * i) + complex_comp;
+      ioss_ssize_t stride       = re_im * comp_count;
 
       if (ioss_type == Ioss::Field::REAL || ioss_type == Ioss::Field::COMPLEX) {
         map->map_field_to_db_scalar_order(static_cast<double *>(variables), temp, begin_offset,

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_Utils.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_Utils.C
@@ -5,6 +5,7 @@
 // See packages/seacas/LICENSE for details
 
 #include <Ioss_Assembly.h>
+#include <Ioss_CodeTypes.h>
 #include <Ioss_ElementTopology.h>
 #include <Ioss_Region.h>
 #include <Ioss_SmartAssert.h>
@@ -616,8 +617,8 @@ namespace Ioex {
     for (const auto &block : element_blocks) {
 
       if (Ioss::Utils::block_is_omitted(block)) {
-        ssize_t min_id = block->get_offset() + 1;
-        ssize_t max_id = min_id + block->entity_count() - 1;
+        ioss_ssize_t min_id = block->get_offset() + 1;
+        ioss_ssize_t max_id = min_id + block->entity_count() - 1;
         for (size_t i = 0; i < elements.size(); i++) {
           if (min_id <= elements[i] && elements[i] <= max_id) {
             omitted     = true;

--- a/packages/seacas/libraries/ioss/src/gen_struc/Iogs_GeneratedMesh.C
+++ b/packages/seacas/libraries/ioss/src/gen_struc/Iogs_GeneratedMesh.C
@@ -15,7 +15,6 @@
 #include <gen_struc/Iogs_GeneratedMesh.h>
 #include <numeric>
 #include <string>
-#include <sys/types.h> // for ssize_t
 #include <tokenize.h>  // for tokenize
 #include <vector>      // for vector
 

--- a/packages/seacas/libraries/ioss/src/generated/Iogn_GeneratedMesh.C
+++ b/packages/seacas/libraries/ioss/src/generated/Iogn_GeneratedMesh.C
@@ -6,6 +6,7 @@
 
 #include <generated/Iogn_GeneratedMesh.h>
 
+#include <Ioss_CodeTypes.h>
 #include <Ioss_Hex8.h>
 #include <Ioss_Pyramid5.h>
 #include <Ioss_Shell4.h>
@@ -21,7 +22,6 @@
 #include <iostream>
 #include <numeric>
 #include <string>
-#include <sys/types.h> // for ssize_t
 #include <tokenize.h>  // for tokenize
 #include <vector>      // for vector
 
@@ -1638,9 +1638,9 @@ namespace Iogn {
       // Insert face_ordinal in between each entry in elem_sides...
       // Face will be 0 for all shells...
       elem_sides.resize(2 * sideset_side_count_proc(id));
-      ssize_t face_ordinal = 0;
-      ssize_t i            = 2 * sideset_side_count_proc(id) - 1;
-      ssize_t j            = sideset_side_count_proc(id) - 1;
+      ioss_ssize_t face_ordinal = 0;
+      ioss_ssize_t i            = 2 * sideset_side_count_proc(id) - 1;
+      ioss_ssize_t j            = sideset_side_count_proc(id) - 1;
       while (i >= 0) {
         elem_sides[i--] = face_ordinal;
         elem_sides[i--] = elem_sides[j--];

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.C
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.C
@@ -8,7 +8,6 @@
 
 #include <Ioss_Utils.h>
 #include <fmt/ostream.h>
-#include <sys/types.h> // for ssize_t
 #include <tokenize.h>  // for tokenize
 
 #include <algorithm>

--- a/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.C
@@ -373,7 +373,7 @@ namespace Iovs_exodus {
         const Ioss::VariableType *var_type         = field.transformed_storage();
         Ioss::Field::BasicType    ioss_type        = field.get_type();
         std::vector<double>       temp(num_to_get);
-        ssize_t                   eb_offset  = eb->get_offset();
+        ioss_ssize_t              eb_offset  = eb->get_offset();
         int                       comp_count = var_type->component_count();
         int                       bid        = get_id(eb, &ids_);
 
@@ -394,8 +394,8 @@ namespace Iovs_exodus {
             std::string var_name = var_type->label_name(field_name, i + 1, field_suffix_separator);
             component_names.push_back(var_name);
 
-            ssize_t begin_offset = (re_im * i) + complex_comp;
-            ssize_t stride       = re_im * comp_count;
+            ioss_ssize_t begin_offset = (re_im * i) + complex_comp;
+            ioss_ssize_t stride       = re_im * comp_count;
 
             if (ioss_type == Ioss::Field::REAL || ioss_type == Ioss::Field::COMPLEX) {
               this->elemMap.map_field_to_db_scalar_order(


### PR DESCRIPTION
Instead, make an Ioss-specific typename to avoid conflicting with other
libraries using `ssize_t` in their code (either consumers of Ioss or
third parties that Ioss itself uses).