### PR TITLE
IOSS: include cctype to define ::toupper and std::isdigit

### DIFF
--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
@@ -2,9 +2,9 @@
 
 // #######################  Start Clang Header Tool Managed Headers ########################
 // clang-format off
-#include <ctype.h>                                   // for toupper
 #include <stddef.h>                                  // for size_t
 #include <algorithm>                                 // for remove, etc
+#include <cctype>                                    // for toupper, isdigit
 #include <iterator>                                  // for insert_iterator
 #include <map>
 #include <set>                                       // for set


### PR DESCRIPTION
`cctype` includes `ctype.h`, so `ctype.h` is no longer included here.