### PR TITLE
Include cctype instead of ctype.h

### DIFF
--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
@@ -2,7 +2,7 @@
 
 // #######################  Start Clang Header Tool Managed Headers ########################
 // clang-format off
-#include <ctype.h>                                   // for toupper
+#include <cctype>                                    // for toupper, isspace, isdigit
 #include <stddef.h>                                  // for size_t
 #include <algorithm>                                 // for remove, etc
 #include <iterator>                                  // for insert_iterator


### PR DESCRIPTION
Fixes MSVC2017 compile error where `std::isspace` and `std::isdigit`
are not defined.