### PR TITLE
Extend Ioss_ElementTopology with shell and permutation info

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Beam2.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Beam2.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"       // for IntVector
 #include "Ioss_ElementTopology.h" // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_Beam2.h>
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <cassert>                    // for assert
@@ -62,6 +63,16 @@ Ioss::Beam2::Beam2() : Ioss::ElementTopology(Ioss::Beam2::name, "Beam_2")
   Ioss::ElementTopology::alias(Ioss::Beam2::name, "line");
   Ioss::ElementTopology::alias(Ioss::Beam2::name, "line2");
   Ioss::ElementTopology::alias(Ioss::Beam2::name, "BEAM_2");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Beam2::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Beam2::parametric_dimension() const { return 1; }
@@ -127,3 +138,4 @@ Ioss::ElementTopology *Ioss::Beam2::edge_type(int /* edge_number */) const
 {
   return Ioss::ElementTopology::factory("edge2");
 }
+

--- a/packages/seacas/libraries/ioss/src/Ioss_Beam2.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Beam2.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,10 +46,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Beam2();
-
-  private:
-    static Beam2 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Beam3.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Beam3.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"       // for IntVector
 #include "Ioss_ElementTopology.h" // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_Beam3.h>
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <cassert>                    // for assert
@@ -52,6 +53,16 @@ Ioss::Beam3::Beam3() : Ioss::ElementTopology(Ioss::Beam3::name, "Beam_3")
   Ioss::ElementTopology::alias(Ioss::Beam3::name, "beam3");
   Ioss::ElementTopology::alias(Ioss::Beam3::name, "Rod_3_2D");
   Ioss::ElementTopology::alias(Ioss::Beam3::name, "rod2d3");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Beam3::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Beam3::parametric_dimension() const { return 1; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Beam3.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Beam3.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,10 +46,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Beam3();
-
-  private:
-    static Beam3 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Beam4.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Beam4.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"       // for IntVector
 #include "Ioss_ElementTopology.h" // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_Beam4.h>
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <cassert>                    // for assert
@@ -52,6 +53,16 @@ Ioss::Beam4::Beam4() : Ioss::ElementTopology(Ioss::Beam4::name, "Beam_4")
   Ioss::ElementTopology::alias(Ioss::Beam4::name, "beam4");
   Ioss::ElementTopology::alias(Ioss::Beam4::name, "Rod_4_2D");
   Ioss::ElementTopology::alias(Ioss::Beam4::name, "rod2d4");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Beam4::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Beam4::parametric_dimension() const { return 1; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Beam4.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Beam4.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,10 +46,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Beam4();
-
-  private:
-    static Beam4 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge2.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge2.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"       // for IntVector
 #include "Ioss_ElementTopology.h" // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_Edge2.h>
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <cassert>                    // for assert
@@ -48,6 +49,16 @@ Ioss::Edge2::Edge2() : Ioss::ElementTopology(Ioss::Edge2::name, "Line_2")
   Ioss::ElementTopology::alias(Ioss::Edge2::name, "edge");
   Ioss::ElementTopology::alias(Ioss::Edge2::name, "edge3d2");
   Ioss::ElementTopology::alias(Ioss::Edge2::name, "LINE_2_1D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Edge2::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Edge2::parametric_dimension() const { return 1; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge2.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge2.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     ElementShape shape() const override { return ElementShape::LINE; }
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,10 +45,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Edge2();
-
-  private:
-    static Edge2 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge2D2.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge2D2.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"       // for IntVector
 #include "Ioss_ElementTopology.h" // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_Edge2D2.h>
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <cassert>                    // for assert
@@ -47,6 +48,16 @@ Ioss::Edge2D2::Edge2D2() : Ioss::ElementTopology(Ioss::Edge2D2::name, "Line_2D_2
 {
   Ioss::ElementTopology::alias(Ioss::Edge2D2::name, "Edge_2_2D");
   //  Ioss::ElementTopology::alias(Ioss::Edge2D2::name, "LINE_2");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Edge2D2::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Edge2D2::parametric_dimension() const { return 1; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge2D2.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge2D2.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     ElementShape shape() const override { return ElementShape::LINE; }
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,10 +45,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Edge2D2();
-
-  private:
-    static Edge2D2 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge2D3.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge2D3.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"       // for IntVector
 #include "Ioss_ElementTopology.h" // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_Edge2D3.h>
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <cassert>                    // for assert
@@ -47,6 +48,16 @@ Ioss::Edge2D3::Edge2D3() : Ioss::ElementTopology(Ioss::Edge2D3::name, "Line_3_2D
 {
   Ioss::ElementTopology::alias(Ioss::Edge2D3::name, "Edge_3_2D");
   //  Ioss::ElementTopology::alias(Ioss::Edge2D3::name, "LINE_3");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Edge2D3::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Edge2D3::parametric_dimension() const { return 1; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge2D3.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge2D3.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     ElementShape shape() const override { return ElementShape::LINE; }
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,10 +45,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Edge2D3();
-
-  private:
-    static Edge2D3 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge3.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge3.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"       // for IntVector
 #include "Ioss_ElementTopology.h" // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_Edge3.h>
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <cassert>                    // for assert
@@ -47,6 +48,16 @@ Ioss::Edge3::Edge3() : Ioss::ElementTopology(Ioss::Edge3::name, "Line_3")
 {
   Ioss::ElementTopology::alias(Ioss::Edge3::name, "edge3d3");
   Ioss::ElementTopology::alias(Ioss::Edge3::name, "LINE_3_1D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Edge3::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Edge3::parametric_dimension() const { return 1; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge3.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge3.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     ElementShape shape() const override { return ElementShape::LINE; }
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,10 +45,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Edge3();
-
-  private:
-    static Edge3 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge4.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge4.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"       // for IntVector
 #include "Ioss_ElementTopology.h" // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_Edge4.h>
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <cassert>                    // for assert
@@ -47,6 +48,16 @@ Ioss::Edge4::Edge4() : Ioss::ElementTopology(Ioss::Edge4::name, "Line_4")
 {
   Ioss::ElementTopology::alias(Ioss::Edge4::name, "edge3d4");
   Ioss::ElementTopology::alias(Ioss::Edge4::name, "LINE_4_1D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Edge4::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Edge4::parametric_dimension() const { return 1; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Edge4.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Edge4.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     ElementShape shape() const override { return ElementShape::LINE; }
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,10 +45,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Edge4();
-
-  private:
-    static Edge4 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_ElementPermutation.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_ElementPermutation.C
@@ -1,0 +1,537 @@
+// Copyright(C) 1999-2021 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#include <Ioss_CodeTypes.h> // for IntVector
+#include <Ioss_ElementTopology.h>
+#include <Ioss_ElementPermutation.h>
+#include <Ioss_Utils.h>
+
+#include <cassert> // for assert
+#include <cstddef> // for size_t
+#include <fmt/ostream.h>
+#include <ostream> // for basic_ostream, etc
+#include <string>  // for string, char_traits, etc
+#include <utility> // for pair
+#include <vector>  // for vector
+
+#include <fmt/ostream.h>
+
+namespace Ioss {
+void EPRegistry::insert(const Ioss::EPM_VP &value, bool delete_me)
+{
+  std::cout << value.second->name() << ": " << value.first << std::endl;
+  m_registry.insert(value);
+  if (delete_me) {
+    m_deleteThese.push_back(value.second);
+  }
+}
+
+EPRegistry::~EPRegistry()
+{
+  for (auto &entry : m_deleteThese) {
+    delete entry;
+  }
+}
+
+//=========================================================================================
+ElementPermutation::ElementPermutation(std::string type, bool delete_me)
+    : m_name(std::move(type))
+{
+  registry().insert(EPM_VP(m_name, this), delete_me);
+  std::string lname = Ioss::Utils::lowercase(m_name);
+  if (lname != m_name) {
+    alias(m_name, lname);
+  }
+}
+
+void ElementPermutation::alias(const std::string &base, const std::string &syn)
+{
+  registry().insert(EPM_VP(syn, factory(base)), false);
+  std::string lsyn = Ioss::Utils::lowercase(syn);
+  if (lsyn != syn) {
+    alias(base, lsyn);
+  }
+}
+
+void ElementPermutation::alias(const std::string &syn)
+{
+  alias(m_name, syn);
+}
+
+void ElementPermutation::alias(const std::string &base, const std::vector<std::string> &syns)
+{
+  for(const std::string& syn : syns)
+    alias(base, syn);
+}
+
+void ElementPermutation::alias(const std::vector<std::string> &syns)
+{
+    alias(m_name, syns);
+}
+
+bool ElementPermutation::is_alias(const std::string &my_alias) const
+{
+  std::string low_my_alias = Ioss::Utils::lowercase(my_alias);
+  auto        iter         = registry().find(low_my_alias);
+  if (iter == registry().end()) {
+    return false;
+  }
+  return this == (*iter).second;
+}
+
+EPRegistry &ElementPermutation::registry()
+{
+  static EPRegistry registry_;
+  return registry_;
+}
+
+Ioss::ElementPermutation::~ElementPermutation() = default;
+
+
+ElementPermutation *Ioss::ElementPermutation::factory(const std::string &type, bool ok_to_fail)
+{
+  std::string ltype = Ioss::Utils::lowercase(type);
+
+  Ioss::ElementPermutation *inst = nullptr;
+  auto                   iter = registry().find(ltype);
+
+  if (iter == registry().end()) {
+    std::string base1 = Ioss::SuperPermutation::basename;
+    if (ltype.compare(0, base1.length(), base1) == 0) {
+      // A ring permutation can have a varying number of nodes.  Create
+      // a permutation type for this ring permutation. The node count
+      // should be encoded in the 'type' as '[base1]42' for a 42-node
+      // ring permutation.
+
+      Ioss::SuperPermutation::make_super(ltype);
+      iter = registry().find(ltype);
+    }
+  }
+
+  if (iter == registry().end()) {
+    if (!ok_to_fail) {
+      std::ostringstream errmsg;
+      fmt::print(errmsg, "ERROR: The permutation type '{}' is not supported.", type);
+      IOSS_ERROR(errmsg);
+    }
+  }
+  else {
+    inst = (*iter).second;
+  }
+  return inst;
+}
+
+NameList ElementPermutation::describe()
+{
+  Ioss::NameList names;
+  describe(&names);
+  return names;
+}
+
+int ElementPermutation::describe(NameList *names)
+{
+  int count = 0;
+  for (auto &entry : registry()) {
+    names->push_back(entry.first);
+    count++;
+  }
+  return count;
+}
+
+const std::string &ElementPermutation::name() const { return m_name; }
+
+unsigned ElementPermutation::num_permutations() const { return m_numPermutations; }
+
+unsigned ElementPermutation::num_positive_permutations() const { return m_numPositivePermutations; }
+
+bool ElementPermutation::is_positive_polarity(Permutation permutation) const { return permutation < m_numPositivePermutations; }
+
+bool ElementPermutation::valid_permutation(Permutation permutation) const { return permutation < m_numPermutations; }
+
+bool ElementPermutation::fill_permutation_indices(Permutation permutation, std::vector<Ordinal>& nodeOrdinalVector) const
+{
+  if (!valid_permutation(permutation)) return false;
+
+  nodeOrdinalVector.resize(num_permutation_nodes());
+  const auto& ordinals = m_permutationNodeOrdinals[permutation];
+  for(unsigned i=0; i<num_permutation_nodes(); i++) {
+    nodeOrdinalVector[i] = ordinals[i];
+  }
+
+  return true;
+}
+
+std::vector<Ordinal> ElementPermutation::permutation_indices(Permutation permutation) const
+{
+  std::vector<Ordinal> nodeOrdinalVector;
+  fill_permutation_indices(permutation, nodeOrdinalVector);
+  return nodeOrdinalVector;
+}
+
+uint8_t ElementPermutation::num_permutation_nodes() const
+{
+  return m_numPermutationNodes;
+}
+
+void ElementPermutation::set_permutation(uint8_t numPermutationNodes_,
+                                         uint8_t numPermutations_,
+                                         uint8_t numPositivePermutations_,
+                                         const std::vector<std::vector<uint8_t>>& permutationNodeOrdinals_)
+{
+  assert(permutationNodeOrdinals_.size() == numPermutations_);
+  assert(numPositivePermutations_ <= numPermutations_);
+
+  m_numPermutations = numPermutations_;
+  m_numPositivePermutations = numPositivePermutations_;
+  m_numPermutationNodes = numPermutationNodes_;
+
+  for(const auto& ordinals : permutationNodeOrdinals_) {
+    if(ordinals.size() != numPermutationNodes_) {
+      std::ostringstream errmsg;
+      fmt::print(errmsg,
+          "ERROR: Number of low order permutation ordinals: {} for permutation: {} does not match permutation value: {}",
+          ordinals.size(), name(), numPermutationNodes_);
+      IOSS_ERROR(errmsg);
+    }
+
+    for(const auto ordinal : ordinals) {
+      if(ordinal >= numPermutationNodes_) {
+        std::ostringstream errmsg;
+        fmt::print(errmsg,
+            "ERROR: Invalid value of ordinal: {} for permutation: {}", ordinal, numPermutationNodes_);
+        IOSS_ERROR(errmsg);
+      }
+    }
+  }
+
+  m_permutationNodeOrdinals = permutationNodeOrdinals_;
+}
+
+bool ElementPermutation::equal_(const ElementPermutation &rhs, bool quiet) const
+{
+  if (this->m_name.compare(rhs.m_name) != 0) {
+    if (!quiet) {
+      fmt::print(Ioss::OUTPUT(), "Element Permutation: NAME mismatch ({} vs. {})\n",
+                 this->m_name.c_str(), rhs.m_name.c_str());
+    }
+    return false;
+  }
+
+  if (this->m_numPermutations != rhs.m_numPermutations) {
+    if (!quiet) {
+      fmt::print(Ioss::OUTPUT(), "Element Permutation: NUM PERMUTATION mismatch ({} vs. {})\n",
+                 this->m_numPermutations, rhs.m_numPermutations);
+    }
+    return false;
+  }
+
+  if (this->m_numPositivePermutations != rhs.m_numPositivePermutations) {
+    if (!quiet) {
+      fmt::print(Ioss::OUTPUT(), "Element Permutation: NUM POSITIVE PERMUTATION mismatch ({} vs. {})\n",
+                 this->m_numPositivePermutations, rhs.m_numPositivePermutations);
+    }
+    return false;
+  }
+
+  if (this->m_numPermutationNodes != rhs.m_numPermutationNodes) {
+    if (!quiet) {
+      fmt::print(Ioss::OUTPUT(), "Element Permutation: NUM PERMUTATION NODES mismatch ({} vs. {})\n",
+                 this->m_numPermutationNodes, rhs.m_numPermutationNodes);
+    }
+    return false;
+  }
+
+  if (this->m_permutationNodeOrdinals != rhs.m_permutationNodeOrdinals) {
+    if (!quiet) {
+      fmt::print(Ioss::OUTPUT(), "Element Permutation: PERMUTATION NODE ORDINALS mismatch\n");
+    }
+    return false;
+  }
+
+  return true;
+}
+
+bool ElementPermutation::operator==(const ElementPermutation &rhs) const
+{
+  return equal_(rhs, true);
+}
+
+bool ElementPermutation::operator!=(const ElementPermutation &rhs) const
+{
+  return !(*this == rhs);
+}
+
+bool ElementPermutation::equal(const ElementPermutation &rhs) const
+{
+  return equal_(rhs, false);
+}
+
+//====================================================================================================
+const char *NullPermutation::name = "null";
+
+void NullPermutation::factory()
+{
+  static NullPermutation registerThis;
+}
+
+NullPermutation::NullPermutation() : ElementPermutation(NullPermutation::name)
+{
+  set_permutation(0, 0, 0, {});
+}
+
+//====================================================================================================
+const char *ParticlePermutation::name = "particle";
+
+void ParticlePermutation::factory()
+{
+  static ParticlePermutation registerThis;
+}
+
+ParticlePermutation::ParticlePermutation() : ElementPermutation(ParticlePermutation::name)
+{
+  set_permutation(1, 1, 1, {{0}});
+}
+
+//====================================================================================================
+const char *LinePermutation::name = "line";
+
+void LinePermutation::factory()
+{
+  static LinePermutation registerThis;
+}
+
+LinePermutation::LinePermutation() : ElementPermutation(LinePermutation::name)
+{
+  set_permutation(2, 2, 1, {{0, 1}, {1, 0}});
+}
+
+//====================================================================================================
+const char *SpringPermutation::name = "spring";
+
+void SpringPermutation::factory()
+{
+  static SpringPermutation registerThis;
+}
+
+SpringPermutation::SpringPermutation() : ElementPermutation(SpringPermutation::name)
+{
+  set_permutation(2, 2, 2, {{0, 1}, {1, 0}});
+}
+
+//====================================================================================================
+const char *TriPermutation::name = "tri";
+
+void TriPermutation::factory()
+{
+  static TriPermutation registerThis;
+}
+
+TriPermutation::TriPermutation() : ElementPermutation(TriPermutation::name)
+{
+  set_permutation(3, 6, 3,
+                  {{0, 1, 2},
+                   {2, 0, 1},
+                   {1, 2, 0},
+                   {0, 2, 1},
+                   {2, 1, 0},
+                   {1, 0, 2}});
+}
+
+//====================================================================================================
+const char *QuadPermutation::name = "quad";
+
+void QuadPermutation::factory()
+{
+  static QuadPermutation registerThis;
+}
+
+QuadPermutation::QuadPermutation() : ElementPermutation(QuadPermutation::name)
+{
+  std::cout << "In quad constructor" << std::endl;
+
+  set_permutation(4, 8, 4,
+                  {{0, 1, 2, 3},
+                   {3, 0, 1, 2},
+                   {2, 3, 0, 1},
+                   {1, 2, 3, 0},
+                   {0, 3, 2, 1},
+                   {3, 2, 1, 0},
+                   {2, 1, 0, 3},
+                   {1, 0, 3, 2}});
+}
+
+//====================================================================================================
+const char *TetPermutation::name = "tet";
+
+void TetPermutation::factory()
+{
+  static TetPermutation registerThis;
+}
+
+TetPermutation::TetPermutation() : ElementPermutation(TetPermutation::name)
+{
+  set_permutation(4, 12, 12,
+                  {{0, 1, 2, 3},
+                   {1, 2, 0, 3},
+                   {2, 0, 1, 3},
+                   {0, 3, 1, 2},
+                   {3, 1, 0, 2},
+                   {1, 0, 3, 2},
+                   {0, 2, 3, 1},
+                   {2, 3, 0, 1},
+                   {3, 0, 2, 1},
+                   {1, 3, 2, 0},
+                   {3, 2, 1, 0},
+                   {2, 1, 3, 0}});
+}
+
+//====================================================================================================
+const char *PyramidPermutation::name = "pyramid";
+
+void PyramidPermutation::factory()
+{
+  static PyramidPermutation registerThis;
+}
+
+PyramidPermutation::PyramidPermutation() : ElementPermutation(PyramidPermutation::name)
+{
+  set_permutation(5, 4, 4,
+                  {{0, 1, 2, 3, 4},
+                   {1, 2, 3, 0, 4},
+                   {2, 3, 0, 1, 4},
+                   {3, 0, 1, 2, 4}});
+}
+
+//====================================================================================================
+const char *WedgePermutation::name = "wedge";
+
+void WedgePermutation::factory()
+{
+  static WedgePermutation registerThis;
+}
+
+WedgePermutation::WedgePermutation() : ElementPermutation(WedgePermutation::name)
+{
+  set_permutation(6, 6, 6,
+                  {{0, 1, 2, 3, 4, 5},
+                   {1, 2, 0, 4, 5, 3},
+                   {2, 0, 1, 5, 3, 4},
+                   {3, 5, 4, 0, 2, 1},
+                   {5, 4, 3, 2, 1, 0},
+                   {4, 3, 5, 1, 0, 2}});
+}
+
+//====================================================================================================
+const char *HexPermutation::name = "hex";
+
+void HexPermutation::factory()
+{
+  static HexPermutation registerThis;
+}
+
+HexPermutation::HexPermutation() : ElementPermutation(HexPermutation::name)
+{
+  set_permutation(8, 24, 24,
+                  {{0, 1, 2, 3, 4, 5, 6, 7},
+                   {0, 1, 5, 4, 3, 2, 6, 7},
+                   {0, 4, 7, 3, 1, 5, 6, 2},
+                   {1, 2, 3, 0, 5, 6, 7, 4},
+                   {1, 2, 6, 5, 0, 3, 7, 4},
+                   {1, 5, 4, 0, 2, 6, 7, 3},
+                   {2, 3, 0, 1, 6, 7, 4, 5},
+                   {2, 3, 7, 6, 1, 0, 4, 5},
+                   {2, 6, 5, 1, 3, 7, 4, 0},
+                   {3, 0, 1, 2, 7, 4, 5, 6},
+                   {3, 0, 4, 7, 2, 1, 5, 6},
+                   {3, 7, 6, 2, 0, 4, 5, 1},
+                   {4, 0, 1, 5, 7, 3, 2, 6},
+                   {4, 7, 3, 0, 5, 6, 2, 1},
+                   {4, 7, 6, 5, 0, 3, 2, 1},
+                   {5, 1, 2, 6, 4, 0, 3, 7},
+                   {5, 4, 0, 1, 6, 7, 3, 2},
+                   {5, 4, 7, 6, 1, 0, 3, 2},
+                   {6, 2, 3, 7, 5, 1, 0, 4},
+                   {6, 5, 1, 2, 7, 4, 0, 3},
+                   {6, 5, 4, 7, 2, 1, 0, 3},
+                   {7, 3, 0, 4, 6, 2, 1, 5},
+                   {7, 6, 2, 3, 4, 5, 1, 0},
+                   {7, 6, 5, 4, 3, 2, 1, 0}});
+}
+
+//====================================================================================================
+// Permutation based on round-robin labeling i,e "ring" permutation
+// Super permutation with 4 nodes will have the following positive permutations
+// {0, 1, 2, 3}, {1, 2, 3, 0}, {2, 3, 0, 1}, {3, 0, 1, 2}
+// and the following negative permutations
+// {0, 3, 2, 1}, {3, 2, 1, 0}, {2, 1, 0, 3}, {1, 0, 3, 2}
+const char *SuperPermutation::basename = "super";
+
+std::string SuperPermutation::get_name(unsigned n)
+{
+  return basename + std::to_string(n);
+}
+
+void SuperPermutation::make_super(const std::string &type)
+{
+  // Decode name to determine number of nodes...
+  // Assume that digits at end specify number of nodes.
+  size_t digits = type.find_last_not_of("0123456789");
+  if (digits != std::string::npos) {
+    std::string node_count_str = type.substr(digits + 1);
+    int         node_count     = std::stoi(node_count_str);
+
+    SuperPermutation::factory(node_count);
+  }
+}
+
+void SuperPermutation::factory() {}
+
+void SuperPermutation::factory(unsigned n)
+{
+  auto iter = registry().find(get_name(n));
+  if (iter == registry().end()) {
+    new SuperPermutation(n);
+  }
+}
+
+// Make sure the permutation is deleted ... boolean arg is true
+SuperPermutation::SuperPermutation() : ElementPermutation(get_name(0), true)
+{
+  set_permutation(0, 0, 0, {});
+}
+
+// Make sure the permutation is deleted... boolean arg is true
+SuperPermutation::SuperPermutation(unsigned n) : ElementPermutation(get_name(n), true)
+{
+  set_permutation(n, 2*n, n, get_super_permutations(n));
+}
+
+std::vector<std::vector<uint8_t>> SuperPermutation::get_super_permutations(unsigned n)
+{
+  std::vector<std::vector<uint8_t>> superPerms;
+
+  // Positive permutations
+  for(unsigned i=0; i<n; i++) {
+    std::vector<uint8_t> perm;
+
+    for(unsigned j=0; j<n; j++) {
+      perm.push_back( (i+j)%n );
+    }
+  }
+
+  // Negative permutations
+  for(unsigned i=0; i<n; i++) {
+    std::vector<uint8_t> perm;
+
+    for(unsigned j=0; j<n; j++) {
+      perm.push_back( ((i+n)-j)%n );
+    }
+  }
+
+  return superPerms;
+}
+
+} // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_ElementPermutation.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_ElementPermutation.h
@@ -1,0 +1,283 @@
+// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#pragma once
+
+#include <Ioss_CodeTypes.h>
+#include <Ioss_Utils.h>
+#include <map>    // for map, map<>::value_compare
+#include <string> // for string, operator<
+#include <vector> // for vector
+#include <assert.h>
+
+namespace Ioss {
+  class ElementTopology;
+  class ElementPermutation;
+} // namespace Ioss
+
+namespace Ioss {
+
+using Ordinal = uint16_t;
+using Permutation = uint8_t;
+
+static constexpr Ordinal InvalidOrdinal = 65535;
+static constexpr Permutation InvalidPermutation = 128;
+
+using ElementPermutationMap = std::map<std::string, ElementPermutation *, std::less<std::string>>;
+using EPM_VP                = ElementPermutationMap::value_type;
+
+class EPRegistry
+{
+public:
+  void                            insert(const Ioss::EPM_VP &value, bool delete_me);
+  ElementPermutationMap::iterator begin() { return m_registry.begin(); }
+  ElementPermutationMap::iterator end() { return m_registry.end(); }
+  ElementPermutationMap::iterator find(const std::string &type) { return m_registry.find(type); }
+
+  ~EPRegistry();
+
+private:
+  Ioss::ElementPermutationMap             m_registry;
+  std::vector<Ioss::ElementPermutation *> m_deleteThese;
+};
+
+// Permutation data is stored such that the positive permutations are listed first ... the order of the
+// positive permutations within that group is irrelevant. The remaining permutations listed after the
+// positive ones are the negative permutations hence, any permutation index outside of the positive
+// range is a negative permutation. By convention, the first permutation listed matches the default
+// listed in the Exodus manual
+
+class ElementPermutation
+{
+public:
+  ElementPermutation(const ElementPermutation &) = delete;
+  ElementPermutation &operator=(const ElementPermutation &) = delete;
+
+  virtual ~ElementPermutation();
+
+  void alias(const std::string &base, const std::string &syn);
+  void alias(const std::string &syn);
+  void alias(const std::string &base, const std::vector<std::string> &syns);
+  void alias(const std::vector<std::string> &syns);
+  bool is_alias(const std::string &my_alias) const;
+
+  unsigned num_permutations() const;
+
+  // The number of positive permutations must be less than or equal to the total number of permutations
+  unsigned num_positive_permutations() const;
+
+  bool is_positive_polarity(Permutation permutation) const;
+
+  // Permutation type is unsigned so only need to check upper bound
+  bool valid_permutation(Permutation permutation) const;
+
+  // For a validated permutation, return the node ordinals
+  bool fill_permutation_indices(Permutation permutation, std::vector<Ordinal>& nodeOrdinalVector) const;
+
+  // For a given permutation, return the node ordinals
+  std::vector<Ordinal> permutation_indices(Permutation permutation) const;
+
+  uint8_t num_permutation_nodes() const;
+
+  const std::string &name() const;
+
+  static ElementPermutation *factory(const std::string &type, bool ok_to_fail = false);
+
+  /** \brief Get the names of element permutations known to Ioss.
+   *
+   *  \param[out] names The list of known element topology names.
+   *  \returns The number of known element topologies.
+   */
+  static int              describe(NameList *names);
+
+  /** \brief Get the names of element permutations known to Ioss.
+   *
+   *  \returns The list of known element topology names.
+   */
+  static NameList         describe();
+
+  bool operator==(const Ioss::ElementPermutation &rhs) const;
+  bool operator!=(const Ioss::ElementPermutation &rhs) const;
+  bool equal(const Ioss::ElementPermutation &rhs) const;
+
+protected:
+  ElementPermutation(std::string type, bool delete_me = false);
+
+  // Store low order permutation data regarding this topology .. the positive permutations are listed first
+  // If this topology is a high order topology, the data is only for the nodes of the associated low order
+  // topology. This implies that any usage of this assumes that the higher order nodes are numbered correctly
+  // relative to the low order nodes.
+  //
+  //        {{0, 1, 2,  3, 4, 5},               {{0, 1, 2},
+  //         {2, 0, 1,  5, 3, 4},                {2, 0, 1},
+  //  Tri6   {1, 2, 0,  4, 5, 3},   -->    Tri3  {1, 2, 0},
+  //         {0, 2, 1,  5, 4, 3},                {0, 2, 1},
+  //         {2, 1, 0,  4, 3, 5},                {2, 1, 0},
+  //         {1, 0, 2,  3, 5, 4}}                {1, 0, 2}}
+
+  void set_permutation(uint8_t numPermutationNodes_, uint8_t numPermutations_, uint8_t numPositivePermutations_,
+                       const std::vector<std::vector<uint8_t>>& permutationNodeOrdinals_);
+
+  static EPRegistry &registry();
+private:
+  bool               equal_(const Ioss::ElementPermutation &rhs, bool quiet) const;
+
+  std::string m_name{};
+  uint8_t m_numPermutations{0};
+  uint8_t m_numPositivePermutations{0};
+  uint8_t m_numPermutationNodes{0};
+  std::vector<std::vector<uint8_t>> m_permutationNodeOrdinals{};
+};
+
+class NullPermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~NullPermutation() override    = default;
+  NullPermutation(const NullPermutation &) = delete;
+
+protected:
+  NullPermutation();
+};
+
+class ParticlePermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~ParticlePermutation() override    = default;
+  ParticlePermutation(const ParticlePermutation &) = delete;
+
+protected:
+  ParticlePermutation();
+};
+
+class LinePermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~LinePermutation() override    = default;
+  LinePermutation(const LinePermutation &) = delete;
+
+protected:
+  LinePermutation();
+};
+
+class SpringPermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~SpringPermutation() override    = default;
+  SpringPermutation(const SpringPermutation &) = delete;
+
+protected:
+  SpringPermutation();
+};
+
+class TriPermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~TriPermutation() override    = default;
+  TriPermutation(const TriPermutation &) = delete;
+
+protected:
+  TriPermutation();
+};
+
+class QuadPermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~QuadPermutation() override    = default;
+  QuadPermutation(const QuadPermutation &) = delete;
+
+protected:
+  QuadPermutation();
+};
+
+class TetPermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~TetPermutation() override    = default;
+  TetPermutation(const TetPermutation &) = delete;
+
+protected:
+  TetPermutation();
+};
+
+class PyramidPermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~PyramidPermutation() override    = default;
+  PyramidPermutation(const PyramidPermutation &) = delete;
+
+protected:
+  PyramidPermutation();
+};
+
+class WedgePermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~WedgePermutation() override    = default;
+  WedgePermutation(const WedgePermutation &) = delete;
+
+protected:
+  WedgePermutation();
+};
+
+class HexPermutation : public ElementPermutation
+{
+public:
+  static const char *name;
+
+  static void factory();
+  ~HexPermutation() override    = default;
+  HexPermutation(const HexPermutation &) = delete;
+
+protected:
+  HexPermutation();
+};
+
+class SuperPermutation : public ElementPermutation
+{
+public:
+  static const char *basename;
+
+  static void make_super(const std::string &type);
+  static void factory();
+  static void factory(unsigned n);
+  ~SuperPermutation() override    = default;
+  SuperPermutation(const SuperPermutation &) = delete;
+
+  static std::string get_name(unsigned n);
+protected:
+  SuperPermutation();
+  explicit SuperPermutation(unsigned n);
+
+  static std::vector<std::vector<uint8_t>> get_super_permutations(unsigned n);
+};
+} // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_ElementTopology.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_ElementTopology.C
@@ -25,6 +25,11 @@ void Ioss::ETRegistry::insert(const Ioss::ETM_VP &value, bool delete_me)
   }
 }
 
+void Ioss::ETRegistry::add_alias(const std::string &base, const std::string &syn)
+{
+  m_alias[base].insert(syn);
+}
+
 Ioss::ETRegistry::~ETRegistry()
 {
   for (auto &entry : m_deleteThese) {
@@ -48,10 +53,32 @@ Ioss::ElementTopology::ElementTopology(std::string type, std::string master_elem
 void Ioss::ElementTopology::alias(const std::string &base, const std::string &syn)
 {
   registry().insert(Ioss::ETM_VP(syn, factory(base)), false);
+  registry().add_alias(base, syn);
   std::string lsyn = Ioss::Utils::lowercase(syn);
   if (lsyn != syn) {
     alias(base, lsyn);
   }
+}
+
+std::vector<std::string> Ioss::ElementTopology::get_aliases(const std::string &base)
+{
+  std::string lbase = Ioss::Utils::lowercase(base);
+
+  auto        iter = registry().find_alias(lbase);
+  std::vector<std::string> aliases;
+
+  if (iter != registry().end_alias()) {
+    const std::set<std::string>& values = (*iter).second;
+    if(values.count(base) == 0) {
+      aliases.push_back(base);
+    }
+
+    for(const std::string& entry : values) {
+      aliases.push_back(entry);
+    }
+  }
+
+  return aliases;
 }
 
 Ioss::ETRegistry &Ioss::ElementTopology::registry()

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex16.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex16.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Hex16.h>
 #include <cassert> // for assert
@@ -72,6 +73,16 @@ void Ioss::Hex16::factory()
 Ioss::Hex16::Hex16() : Ioss::ElementTopology(Ioss::Hex16::name, "Hexahedron_16")
 {
   Ioss::ElementTopology::alias(Ioss::Hex16::name, "Solid_Hex_16_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Hex16::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::HexPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Hex16::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex16.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex16.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     bool edges_similar() const override { return false; } // true if all edges have same topology
@@ -49,10 +51,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Hex16();
-
-  private:
-    static Hex16 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex20.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex20.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Hex20.h>
 #include <cassert> // for assert
@@ -72,6 +73,16 @@ void Ioss::Hex20::factory()
 Ioss::Hex20::Hex20() : Ioss::ElementTopology(Ioss::Hex20::name, "Hexahedron_20")
 {
   Ioss::ElementTopology::alias(Ioss::Hex20::name, "Solid_Hex_20_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Hex20::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::HexPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Hex20::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex20.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex20.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Hex20();
 
   private:
-    static Hex20 instance_;
-
     Hex20(const Hex20 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex27.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex27.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Hex27.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ void Ioss::Hex27::factory()
 Ioss::Hex27::Hex27() : Ioss::ElementTopology(Ioss::Hex27::name, "Hexahedron_27")
 {
   Ioss::ElementTopology::alias(Ioss::Hex27::name, "Solid_Hex_27_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Hex27::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::HexPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Hex27::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex27.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex27.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Hex27();
 
   private:
-    static Hex27 instance_;
-
     Hex27(const Hex27 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex32.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex32.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Hex32.h>
 #include <cassert> // for assert
@@ -74,6 +75,16 @@ void Ioss::Hex32::factory()
 Ioss::Hex32::Hex32() : Ioss::ElementTopology(Ioss::Hex32::name, "Hexahedron_32")
 {
   Ioss::ElementTopology::alias(Ioss::Hex32::name, "Solid_Hex_32_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Hex32::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::HexPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Hex32::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex32.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex32.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Hex32();
 
   private:
-    static Hex32 instance_;
-
     Hex32(const Hex32 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex64.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex64.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Hex64.h>
 #include <cassert> // for assert
@@ -77,6 +78,16 @@ void Ioss::Hex64::factory()
 Ioss::Hex64::Hex64() : Ioss::ElementTopology(Ioss::Hex64::name, "Hexahedron_64")
 {
   Ioss::ElementTopology::alias(Ioss::Hex64::name, "Solid_Hex_64_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Hex64::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::HexPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Hex64::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex64.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex64.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Hex64();
 
   private:
-    static Hex64 instance_;
-
     Hex64(const Hex64 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex8.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex8.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Hex8.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ Ioss::Hex8::Hex8() : Ioss::ElementTopology(Ioss::Hex8::name, "Hexahedron_8")
 {
   Ioss::ElementTopology::alias(Ioss::Hex8::name, "hex");
   Ioss::ElementTopology::alias(Ioss::Hex8::name, "Solid_Hex_8_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Hex8::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::HexPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Hex8::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex8.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex8.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Hex8();
 
   private:
-    static Hex8 instance_;
-
     Hex8(const Hex8 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex9.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex9.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Hex9.h>
 #include <cassert> // for assert
@@ -72,6 +73,16 @@ void Ioss::Hex9::factory()
 Ioss::Hex9::Hex9() : Ioss::ElementTopology(Ioss::Hex9::name, "Hexahedron_9")
 {
   Ioss::ElementTopology::alias(Ioss::Hex9::name, "Solid_Hex_9_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Hex9::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::HexPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Hex9::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Hex9.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Hex9.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Hex9();
 
   private:
-    static Hex9 instance_;
-
     Hex9(const Hex9 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Initializer.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Initializer.C
@@ -6,6 +6,7 @@
 
 #include <Ioss_CodeTypes.h>
 #include <Ioss_StandardElementTypes.h>
+#include <Ioss_ElementPermutation.h>
 #if defined IOSS_THREADSAFE
 #include <mutex>
 #endif
@@ -14,6 +15,18 @@ Ioss::Initializer::Initializer()
 {
   // List all storage types here with a call to their factory method.
   // This is Used to get the linker to pull in all needed libraries.
+  Ioss::NullPermutation::factory();
+  Ioss::ParticlePermutation::factory();
+  Ioss::LinePermutation::factory();
+  Ioss::SpringPermutation::factory();
+  Ioss::TriPermutation::factory();
+  Ioss::QuadPermutation::factory();
+  Ioss::TetPermutation::factory();
+  Ioss::PyramidPermutation::factory();
+  Ioss::WedgePermutation::factory();
+  Ioss::HexPermutation::factory();
+  Ioss::SuperPermutation::factory();
+
   Ioss::Sphere::factory();
 
   Ioss::Edge2::factory();

--- a/packages/seacas/libraries/ioss/src/Ioss_Node.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Node.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Node.h>
 #include <cassert> // for assert
@@ -47,6 +48,15 @@ Ioss::Node::Node() : Ioss::ElementTopology(Ioss::Node::name, "Node_0_3D")
 {
   Ioss::ElementTopology::alias(Ioss::Node::name, "Node_0_2D");
   Ioss::ElementTopology::alias(Ioss::Node::name, "NODE");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Node::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::NullPermutation::name);
+  assert(perm != nullptr);
+  return perm;
 }
 
 int Ioss::Node::parametric_dimension() const { return 0; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Node.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Node.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     ElementShape shape() const override { return ElementShape::POINT; }
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,6 +45,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Node();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid13.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid13.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Pyramid13.h>
 #include <cassert> // for assert
@@ -79,6 +80,16 @@ Ioss::Pyramid13::Pyramid13() : Ioss::ElementTopology(Ioss::Pyramid13::name, "Pyr
 {
   Ioss::ElementTopology::alias(Ioss::Pyramid13::name, "Solid_Pyramid_13_3D");
   Ioss::ElementTopology::alias(Ioss::Pyramid13::name, "pyra13");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Pyramid13::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::PyramidPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Pyramid13::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid13.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid13.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -47,6 +49,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Pyramid13();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid14.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid14.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Pyramid14.h>
 #include <cassert> // for assert
@@ -79,6 +80,16 @@ Ioss::Pyramid14::Pyramid14() : Ioss::ElementTopology(Ioss::Pyramid14::name, "Pyr
 {
   Ioss::ElementTopology::alias(Ioss::Pyramid14::name, "Solid_Pyramid_14_3D");
   Ioss::ElementTopology::alias(Ioss::Pyramid14::name, "pyra14");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Pyramid14::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::PyramidPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Pyramid14::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid14.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid14.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -47,6 +49,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Pyramid14();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid18.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid18.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Pyramid18.h>
 #include <cassert> // for assert
@@ -79,6 +80,16 @@ Ioss::Pyramid18::Pyramid18() : Ioss::ElementTopology(Ioss::Pyramid18::name, "Pyr
 {
   Ioss::ElementTopology::alias(Ioss::Pyramid18::name, "Solid_Pyramid_18_3D");
   Ioss::ElementTopology::alias(Ioss::Pyramid18::name, "pyra18");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Pyramid18::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::PyramidPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Pyramid18::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid18.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid18.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -47,6 +49,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Pyramid18();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid19.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid19.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Pyramid19.h>
 #include <cassert> // for assert
@@ -79,6 +80,16 @@ Ioss::Pyramid19::Pyramid19() : Ioss::ElementTopology(Ioss::Pyramid19::name, "Pyr
 {
   Ioss::ElementTopology::alias(Ioss::Pyramid19::name, "Solid_Pyramid_19_3D");
   Ioss::ElementTopology::alias(Ioss::Pyramid19::name, "pyra19");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Pyramid19::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::PyramidPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Pyramid19::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid19.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid19.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -47,6 +49,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Pyramid19();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid5.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid5.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Pyramid5.h>
 #include <cassert> // for assert
@@ -76,6 +77,16 @@ Ioss::Pyramid5::Pyramid5() : Ioss::ElementTopology(Ioss::Pyramid5::name, "Pyrami
   Ioss::ElementTopology::alias(Ioss::Pyramid5::name, "pyramid");
   Ioss::ElementTopology::alias(Ioss::Pyramid5::name, "Solid_Pyramid_5_3D");
   Ioss::ElementTopology::alias(Ioss::Pyramid5::name, "pyra5");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Pyramid5::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::PyramidPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Pyramid5::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Pyramid5.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Pyramid5.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -47,6 +49,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Pyramid5();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad12.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad12.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Quad12.h>
 #include <cassert> // for assert
@@ -25,7 +26,6 @@ namespace Ioss {
   };
 } // namespace Ioss
 // ========================================================================
-Ioss::Quad12 Ioss::Quad12::instance_;
 
 namespace {
   struct Constants
@@ -54,6 +54,16 @@ Ioss::Quad12::Quad12() : Ioss::ElementTopology(Ioss::Quad12::name, "Quadrilatera
   Ioss::ElementTopology::alias(Ioss::Quad12::name, "QUADRILATERAL_12_2D");
   Ioss::ElementTopology::alias(Ioss::Quad12::name, "Face_Quad_12_3D");
   Ioss::ElementTopology::alias(Ioss::Quad12::name, "quadface12");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Quad12::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::QuadPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Quad12::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad12.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad12.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,12 +45,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Quad12();
 
   private:
-    static Quad12 instance_;
-
     Quad12(const Quad12 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad16.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad16.C
@@ -25,7 +25,6 @@ namespace Ioss {
   };
 } // namespace Ioss
 // ========================================================================
-Ioss::Quad16 Ioss::Quad16::instance_;
 
 namespace {
   struct Constants
@@ -54,6 +53,16 @@ Ioss::Quad16::Quad16() : Ioss::ElementTopology(Ioss::Quad16::name, "Quadrilatera
   Ioss::ElementTopology::alias(Ioss::Quad16::name, "QUADRILATERAL_16_2D");
   Ioss::ElementTopology::alias(Ioss::Quad16::name, "Face_Quad_16_3D");
   Ioss::ElementTopology::alias(Ioss::Quad16::name, "quadface16");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Quad16::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::QuadPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Quad16::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad16.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad16.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,12 +45,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Quad16();
 
   private:
-    static Quad16 instance_;
-
     Quad16(const Quad16 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad4.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad4.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Quad4.h>
 #include <cassert> // for assert
@@ -25,7 +26,6 @@ namespace Ioss {
   };
 } // namespace Ioss
 // ========================================================================
-Ioss::Quad4 Ioss::Quad4::instance_;
 
 namespace {
   struct Constants
@@ -55,6 +55,16 @@ Ioss::Quad4::Quad4() : Ioss::ElementTopology(Ioss::Quad4::name, "Quadrilateral_4
   Ioss::ElementTopology::alias(Ioss::Quad4::name, "QUADRILATERAL_4_2D");
   Ioss::ElementTopology::alias(Ioss::Quad4::name, "Face_Quad_4_3D");
   Ioss::ElementTopology::alias(Ioss::Quad4::name, "quadface4");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Quad4::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::QuadPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Quad4::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad4.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad4.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,12 +45,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Quad4();
 
   private:
-    static Quad4 instance_;
-
     Quad4(const Quad4 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad6.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad6.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Quad6.h>
 #include <cassert> // for assert
@@ -25,7 +26,6 @@ namespace Ioss {
   };
 } // namespace Ioss
 // ========================================================================
-Ioss::Quad6 Ioss::Quad6::instance_;
 
 namespace {
   struct Constants
@@ -54,6 +54,16 @@ Ioss::Quad6::Quad6() : Ioss::ElementTopology(Ioss::Quad6::name, "Quadrilateral_6
   Ioss::ElementTopology::alias(Ioss::Quad6::name, "QUADRILATERAL_6_2D");
   Ioss::ElementTopology::alias(Ioss::Quad6::name, "Face_Quad_6_3D");
   Ioss::ElementTopology::alias(Ioss::Quad6::name, "quadface6");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Quad6::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::QuadPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Quad6::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad6.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad6.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     bool edges_similar() const override { return false; } // true if all edges have same topology
@@ -46,8 +48,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   private:
-    static Quad6 instance_;
     Quad6();
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad8.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad8.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Quad8.h>
 #include <cassert> // for assert
@@ -25,7 +26,6 @@ namespace Ioss {
   };
 } // namespace Ioss
 // ========================================================================
-Ioss::Quad8 Ioss::Quad8::instance_;
 
 namespace {
   struct Constants
@@ -54,6 +54,16 @@ Ioss::Quad8::Quad8() : Ioss::ElementTopology(Ioss::Quad8::name, "Quadrilateral_8
   Ioss::ElementTopology::alias(Ioss::Quad8::name, "QUADRILATERAL_8_2D");
   Ioss::ElementTopology::alias(Ioss::Quad8::name, "Face_Quad_8_3D");
   Ioss::ElementTopology::alias(Ioss::Quad8::name, "quadface8");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Quad8::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::QuadPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Quad8::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad8.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad8.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,12 +45,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Quad8();
 
   private:
-    static Quad8 instance_;
-
     Quad8(const Quad8 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad9.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad9.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Quad9.h>
 #include <cassert> // for assert
@@ -25,7 +26,6 @@ namespace Ioss {
   };
 } // namespace Ioss
 // ========================================================================
-Ioss::Quad9 Ioss::Quad9::instance_;
 
 namespace {
   struct Constants
@@ -54,6 +54,16 @@ Ioss::Quad9::Quad9() : Ioss::ElementTopology(Ioss::Quad9::name, "Quadrilateral_9
   Ioss::ElementTopology::alias(Ioss::Quad9::name, "QUADRILATERAL_9_2D");
   Ioss::ElementTopology::alias(Ioss::Quad9::name, "Face_Quad_9_3D");
   Ioss::ElementTopology::alias(Ioss::Quad9::name, "quadface9");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Quad9::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::QuadPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Quad9::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Quad9.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Quad9.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,12 +45,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Quad9();
 
   private:
-    static Quad9 instance_;
-
     Quad9(const Quad9 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Shell4.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Shell4.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Shell4.h>
 #include <cassert> // for assert
@@ -71,6 +72,16 @@ Ioss::Shell4::Shell4() : Ioss::ElementTopology(Ioss::Shell4::name, "ShellQuadril
   Ioss::ElementTopology::alias(Ioss::Shell4::name, "shell");
   Ioss::ElementTopology::alias(Ioss::Shell4::name, "Shell_Quad_4_3D");
   Ioss::ElementTopology::alias(Ioss::Shell4::name, "SHELL_QUADRILATERAL_4");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Shell4::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::QuadPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Shell4::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Shell4.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Shell4.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return true; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Shell4();
 
   private:
-    static Shell4 instance_;
-
     Shell4(const Shell4 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Shell8.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Shell8.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Shell8.h>
 #include <cassert> // for assert
@@ -70,6 +71,16 @@ Ioss::Shell8::Shell8() : Ioss::ElementTopology(Ioss::Shell8::name, "ShellQuadril
 {
   Ioss::ElementTopology::alias(Ioss::Shell8::name, "Shell_Quad_8_3D");
   Ioss::ElementTopology::alias(Ioss::Shell8::name, "SHELL_QUADRILATERAL_8");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Shell8::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::QuadPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Shell8::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Shell8.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Shell8.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return true; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Shell8();
 
   private:
-    static Shell8 instance_;
-
     Shell8(const Shell8 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Shell9.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Shell9.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Shell9.h>
 #include <cassert> // for assert
@@ -70,6 +71,16 @@ Ioss::Shell9::Shell9() : Ioss::ElementTopology(Ioss::Shell9::name, "ShellQuadril
 {
   Ioss::ElementTopology::alias(Ioss::Shell9::name, "Shell_Quad_9_3D");
   Ioss::ElementTopology::alias(Ioss::Shell9::name, "SHELL_QUADRILATERAL_9");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Shell9::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::QuadPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Shell9::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Shell9.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Shell9.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return true; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Shell9();
 
   private:
-    static Shell9 instance_;
-
     Shell9(const Shell9 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_ShellLine2D2.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_ShellLine2D2.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_ShellLine2D2.h>
 #include <cassert> // for assert
@@ -47,6 +48,16 @@ Ioss::ShellLine2D2::ShellLine2D2() : Ioss::ElementTopology(Ioss::ShellLine2D2::n
 {
   Ioss::ElementTopology::alias(Ioss::ShellLine2D2::name, "Shell_Line_2_2D");
   Ioss::ElementTopology::alias(Ioss::ShellLine2D2::name, "SHELL_LINE_2");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::ShellLine2D2::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::ShellLine2D2::parametric_dimension() const { return 1; }

--- a/packages/seacas/libraries/ioss/src/Ioss_ShellLine2D2.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_ShellLine2D2.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return true; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,12 +45,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     ShellLine2D2();
 
   private:
-    static ShellLine2D2 instance_;
-
     ShellLine2D2(const ShellLine2D2 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_ShellLine2D3.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_ShellLine2D3.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_ShellLine2D3.h>
 #include <cassert> // for assert
@@ -47,6 +48,16 @@ Ioss::ShellLine2D3::ShellLine2D3() : Ioss::ElementTopology(Ioss::ShellLine2D3::n
 {
   Ioss::ElementTopology::alias(Ioss::ShellLine2D3::name, "Shell_Line_3_2D");
   Ioss::ElementTopology::alias(Ioss::ShellLine2D3::name, "SHELL_LINE_3");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::ShellLine2D3::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::LinePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::ShellLine2D3::parametric_dimension() const { return 1; }

--- a/packages/seacas/libraries/ioss/src/Ioss_ShellLine2D3.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_ShellLine2D3.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return true; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,12 +45,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     ShellLine2D3();
 
   private:
-    static ShellLine2D3 instance_;
-
     ShellLine2D3(const ShellLine2D3 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Sphere.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Sphere.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Sphere.h>
 #include <cassert> // for assert
@@ -54,6 +55,16 @@ Ioss::Sphere::Sphere() : Ioss::ElementTopology(Ioss::Sphere::name, "Particle")
   Ioss::ElementTopology::alias(Ioss::Sphere::name, "circle1");
   Ioss::ElementTopology::alias(Ioss::Sphere::name, "point");
   Ioss::ElementTopology::alias(Ioss::Sphere::name, "point1");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Sphere::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::ParticlePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Sphere::parametric_dimension() const { return 0; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Sphere.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Sphere.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,10 +46,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Sphere();
-
-  private:
-    static Sphere instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Spring2.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Spring2.C
@@ -43,7 +43,18 @@ void Ioss::Spring2::factory()
   Ioss::St_Spring2::factory();
 }
 
-Ioss::Spring2::Spring2() : Ioss::ElementTopology(Ioss::Spring2::name, "Spring_2") {}
+Ioss::Spring2::Spring2() : Ioss::ElementTopology(Ioss::Spring2::name, "Spring_2")
+{
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Spring2::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::SpringPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
+}
 
 int Ioss::Spring2::parametric_dimension() const { return 1; }
 int Ioss::Spring2::spatial_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Spring2.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Spring2.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,10 +46,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Spring2();
-
-  private:
-    static Spring2 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Spring3.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Spring3.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Spring3.h>
 #include <cassert> // for assert
@@ -43,7 +44,18 @@ void Ioss::Spring3::factory()
   Ioss::St_Spring3::factory();
 }
 
-Ioss::Spring3::Spring3() : Ioss::ElementTopology(Ioss::Spring3::name, "Spring_3") {}
+Ioss::Spring3::Spring3() : Ioss::ElementTopology(Ioss::Spring3::name, "Spring_3")
+{
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Spring3::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::SpringPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
+}
 
 int Ioss::Spring3::parametric_dimension() const { return 1; }
 int Ioss::Spring3::spatial_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Spring3.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Spring3.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,10 +46,8 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Spring3();
-
-  private:
-    static Spring3 instance_;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Super.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Super.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Super.h>
 #include <cstddef> // for size_t
@@ -38,6 +39,13 @@ Ioss::Super::Super(const std::string &my_name, int node_count)
 {
 }
 
+Ioss::ElementPermutation *Ioss::Super::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::SuperPermutation::get_name(nodeCount));
+  assert(perm != nullptr);
+  return perm;
+}
+
 Ioss::Super::~Super() { delete storageType; }
 
 void Ioss::Super::make_super(const std::string &type)
@@ -48,6 +56,8 @@ void Ioss::Super::make_super(const std::string &type)
   if (digits != std::string::npos) {
     std::string node_count_str = type.substr(digits + 1);
     int         node_count     = std::stoi(node_count_str);
+
+    Ioss::SuperPermutation::factory(node_count);
     new Ioss::Super(type, node_count);
   }
 }

--- a/packages/seacas/libraries/ioss/src/Ioss_Super.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Super.h
@@ -9,6 +9,7 @@
 #include "Ioss_Super.h"
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 #include <string>                 // for string
 namespace Ioss {
   class ElementVariableType;
@@ -34,6 +35,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -54,6 +56,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
   private:
     int                        nodeCount;

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet10.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet10.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tet10.h>
 #include <cassert> // for assert
@@ -71,6 +72,16 @@ Ioss::Tet10::Tet10() : Ioss::ElementTopology(Ioss::Tet10::name, "Tetrahedron_10"
 {
   Ioss::ElementTopology::alias(Ioss::Tet10::name, "tet10");
   Ioss::ElementTopology::alias(Ioss::Tet10::name, "Solid_Tet_10_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tet10::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TetPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tet10::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet10.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet10.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tet10();
 
   private:
-    static Tet10 instance_;
-
     Tet10(const Tet10 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet11.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet11.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tet11.h>
 #include <cassert> // for assert
@@ -72,6 +73,16 @@ Ioss::Tet11::Tet11() : Ioss::ElementTopology(Ioss::Tet11::name, "Tetrahedron_11"
 {
   Ioss::ElementTopology::alias(Ioss::Tet11::name, "tet11");
   Ioss::ElementTopology::alias(Ioss::Tet11::name, "Solid_Tet_11_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tet11::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TetPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tet11::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet11.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet11.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tet11();
 
   private:
-    static Tet11 instance_;
-
     Tet11(const Tet11 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet14.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet14.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tet14.h>
 #include <cassert> // for assert
@@ -76,6 +77,16 @@ Ioss::Tet14::Tet14() : Ioss::ElementTopology(Ioss::Tet14::name, "Tetrahedron_14"
 {
   Ioss::ElementTopology::alias(Ioss::Tet14::name, "tet14");
   Ioss::ElementTopology::alias(Ioss::Tet14::name, "Solid_Tet_14_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tet14::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TetPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tet14::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet14.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet14.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tet14();
 
   private:
-    static Tet14 instance_;
-
     Tet14(const Tet14 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet15.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet15.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tet15.h>
 #include <cassert> // for assert
@@ -76,6 +77,16 @@ Ioss::Tet15::Tet15() : Ioss::ElementTopology(Ioss::Tet15::name, "Tetrahedron_15"
 {
   Ioss::ElementTopology::alias(Ioss::Tet15::name, "tet15");
   Ioss::ElementTopology::alias(Ioss::Tet15::name, "Solid_Tet_15_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tet15::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TetPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tet15::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet15.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet15.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tet15();
 
   private:
-    static Tet15 instance_;
-
     Tet15(const Tet15 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet16.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet16.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tet16.h>
 #include <cassert> // for assert
@@ -76,6 +77,16 @@ Ioss::Tet16::Tet16() : Ioss::ElementTopology(Ioss::Tet16::name, "Tetrahedron_16"
 {
   Ioss::ElementTopology::alias(Ioss::Tet16::name, "tet16");
   Ioss::ElementTopology::alias(Ioss::Tet16::name, "Solid_Tet_16_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tet16::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TetPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tet16::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet16.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet16.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tet16();
 
   private:
-    static Tet16 instance_;
-
     Tet16(const Tet16 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet4.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet4.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tet4.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ Ioss::Tet4::Tet4() : Ioss::ElementTopology(Ioss::Tet4::name, "Tetrahedron_4")
   Ioss::ElementTopology::alias(Ioss::Tet4::name, "tet4");
   Ioss::ElementTopology::alias(Ioss::Tet4::name, "tet");
   Ioss::ElementTopology::alias(Ioss::Tet4::name, "Solid_Tet_4_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tet4::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TetPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tet4::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet4.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet4.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tet4();
 
   private:
-    static Tet4 instance_;
-
     Tet4(const Tet4 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet40.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet40.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tet40.h>
 #include <cassert> // for assert
@@ -76,6 +77,16 @@ Ioss::Tet40::Tet40() : Ioss::ElementTopology(Ioss::Tet40::name, "Tetrahedron_40"
 {
   Ioss::ElementTopology::alias(Ioss::Tet40::name, "tet40");
   Ioss::ElementTopology::alias(Ioss::Tet40::name, "Solid_Tet_40_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tet40::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TetPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tet40::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet40.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet40.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tet40();
 
   private:
-    static Tet40 instance_;
-
     Tet40(const Tet40 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet7.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet7.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tet7.h>
 #include <cassert> // for assert
@@ -77,6 +78,16 @@ Ioss::Tet7::Tet7() : Ioss::ElementTopology(Ioss::Tet7::name, "Tetrahedron_7")
 {
   Ioss::ElementTopology::alias(Ioss::Tet7::name, "tet7");
   Ioss::ElementTopology::alias(Ioss::Tet7::name, "Solid_Tet_7_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tet7::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TetPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tet7::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet7.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet7.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -48,12 +50,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tet7();
 
   private:
-    static Tet7 instance_;
-
     Tet7(const Tet7 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet8.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet8.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tet8.h>
 #include <cassert> // for assert
@@ -71,6 +72,16 @@ Ioss::Tet8::Tet8() : Ioss::ElementTopology(Ioss::Tet8::name, "Tetrahedron_8")
 {
   Ioss::ElementTopology::alias(Ioss::Tet8::name, "tet8");
   Ioss::ElementTopology::alias(Ioss::Tet8::name, "Solid_Tet_8_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tet8::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TetPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tet8::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tet8.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tet8.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -45,12 +47,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tet8();
 
   private:
-    static Tet8 instance_;
-
     Tet8(const Tet8 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri13.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri13.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tri13.h>
 #include <cassert> // for assert
@@ -55,6 +56,16 @@ Ioss::Tri13::Tri13() : Ioss::ElementTopology(Ioss::Tri13::name, "Triangle_13")
   Ioss::ElementTopology::alias(Ioss::Tri13::name, "Face_Tri_13_3D");
   Ioss::ElementTopology::alias(Ioss::Tri13::name, "TRIANGLE_13_2D");
   Ioss::ElementTopology::alias(Ioss::Tri13::name, "triface13");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tri13::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tri13::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri13.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri13.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,12 +46,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tri13();
 
   private:
-    static Tri13 instance_;
-
     Tri13(const Tri13 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri3.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri3.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tri3.h>
 #include <cassert> // for assert
@@ -57,6 +58,16 @@ Ioss::Tri3::Tri3() : Ioss::ElementTopology(Ioss::Tri3::name, "Triangle_3")
   Ioss::ElementTopology::alias(Ioss::Tri3::name, "Face_Tri_3_3D");
   Ioss::ElementTopology::alias(Ioss::Tri3::name, "triface3");
   Ioss::ElementTopology::alias(Ioss::Tri3::name, "TRIANGLE_3_2D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tri3::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tri3::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri3.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri3.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,12 +45,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tri3();
 
   private:
-    static Tri3 instance_;
-
     Tri3(const Tri3 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri4.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri4.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tri4.h>
 #include <cassert> // for assert
@@ -54,6 +55,16 @@ Ioss::Tri4::Tri4() : Ioss::ElementTopology(Ioss::Tri4::name, "Triangle_4")
   Ioss::ElementTopology::alias(Ioss::Tri4::name, "Face_Tri_4_3D");
   Ioss::ElementTopology::alias(Ioss::Tri4::name, "triface4");
   Ioss::ElementTopology::alias(Ioss::Tri4::name, "TRIANGLE_4_2D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tri4::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tri4::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri4.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri4.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,12 +46,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tri4();
 
   private:
-    static Tri4 instance_;
-
     Tri4(const Tri4 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri4a.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri4a.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tri4a.h>
 #include <cassert> // for assert
@@ -52,7 +53,18 @@ void Ioss::Tri4a::factory()
   Ioss::St_Tri4a::factory();
 }
 
-Ioss::Tri4a::Tri4a() : Ioss::ElementTopology(Ioss::Tri4a::name, "Triangle_4a") {}
+Ioss::Tri4a::Tri4a() : Ioss::ElementTopology(Ioss::Tri4a::name, "Triangle_4a")
+{
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tri4a::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
+}
 
 int Ioss::Tri4a::parametric_dimension() const { return 2; }
 int Ioss::Tri4a::spatial_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri4a.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri4a.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -46,12 +48,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tri4a();
 
   private:
-    static Tri4a instance_;
-
     Tri4a(const Tri4a &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri6.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri6.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tri6.h>
 #include <cassert> // for assert
@@ -55,6 +56,16 @@ Ioss::Tri6::Tri6() : Ioss::ElementTopology(Ioss::Tri6::name, "Triangle_6")
   Ioss::ElementTopology::alias(Ioss::Tri6::name, "Face_Tri_6_3D");
   Ioss::ElementTopology::alias(Ioss::Tri6::name, "TRIANGLE_6_2D");
   Ioss::ElementTopology::alias(Ioss::Tri6::name, "triface6");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tri6::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tri6::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri6.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri6.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,12 +46,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tri6();
 
   private:
-    static Tri6 instance_;
-
     Tri6(const Tri6 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri7.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri7.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tri7.h>
 #include <cassert> // for assert
@@ -55,6 +56,16 @@ Ioss::Tri7::Tri7() : Ioss::ElementTopology(Ioss::Tri7::name, "Triangle_7")
   Ioss::ElementTopology::alias(Ioss::Tri7::name, "Face_Tri_7_3D");
   Ioss::ElementTopology::alias(Ioss::Tri7::name, "TRIANGLE_7_2D");
   Ioss::ElementTopology::alias(Ioss::Tri7::name, "triface7");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tri7::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tri7::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri7.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri7.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,12 +46,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tri7();
 
   private:
-    static Tri7 instance_;
-
     Tri7(const Tri7 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri9.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri9.C
@@ -8,6 +8,7 @@
 // Define a variable type for storage of this elements connectivity
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Tri9.h>
 #include <cassert> // for assert
@@ -55,6 +56,16 @@ Ioss::Tri9::Tri9() : Ioss::ElementTopology(Ioss::Tri9::name, "Triangle_9")
   Ioss::ElementTopology::alias(Ioss::Tri9::name, "Face_Tri_9_3D");
   Ioss::ElementTopology::alias(Ioss::Tri9::name, "TRIANGLE_9_2D");
   Ioss::ElementTopology::alias(Ioss::Tri9::name, "triface9");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Tri9::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Tri9::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Tri9.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Tri9.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,12 +46,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Tri9();
 
   private:
-    static Tri9 instance_;
-
     Tri9(const Tri9 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_TriShell3.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_TriShell3.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_TriShell3.h>
 #include <cassert> // for assert
@@ -72,6 +73,16 @@ Ioss::TriShell3::TriShell3() : Ioss::ElementTopology(Ioss::TriShell3::name, "She
   Ioss::ElementTopology::alias(Ioss::TriShell3::name, "Shell_Tri_3_3D");
   Ioss::ElementTopology::alias(Ioss::TriShell3::name, "SHELL_TRIANGLE_3");
   Ioss::ElementTopology::alias(Ioss::TriShell3::name, "shell3");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::TriShell3::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::TriShell3::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_TriShell3.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_TriShell3.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return true; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -46,12 +48,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     TriShell3();
 
   private:
-    static TriShell3 instance_;
-
     TriShell3(const TriShell3 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_TriShell4.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_TriShell4.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_TriShell4.h>
 #include <cassert> // for assert
@@ -70,6 +71,16 @@ Ioss::TriShell4::TriShell4() : Ioss::ElementTopology(Ioss::TriShell4::name, "She
 {
   Ioss::ElementTopology::alias(Ioss::TriShell4::name, "Shell_Tri_4_3D");
   Ioss::ElementTopology::alias(Ioss::TriShell4::name, "SHELL_TRIANGLE_4");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::TriShell4::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::TriShell4::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_TriShell4.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_TriShell4.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return true; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -46,12 +48,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     TriShell4();
 
   private:
-    static TriShell4 instance_;
-
     TriShell4(const TriShell4 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_TriShell6.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_TriShell6.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_TriShell6.h>
 #include <cassert> // for assert
@@ -66,6 +67,16 @@ Ioss::TriShell6::TriShell6() : Ioss::ElementTopology(Ioss::TriShell6::name, "She
   Ioss::ElementTopology::alias(Ioss::TriShell6::name, "Shell_Tri_6_3D");
   Ioss::ElementTopology::alias(Ioss::TriShell6::name, "SHELL_TRIANGLE_6");
   Ioss::ElementTopology::alias(Ioss::TriShell6::name, "SHELL6");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::TriShell6::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::TriShell6::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_TriShell6.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_TriShell6.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return true; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,12 +46,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     TriShell6();
 
   private:
-    static TriShell6 instance_;
-
     TriShell6(const TriShell6 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_TriShell7.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_TriShell7.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h"  // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_TriShell7.h>
 #include <cassert> // for assert
@@ -66,6 +67,16 @@ Ioss::TriShell7::TriShell7() : Ioss::ElementTopology(Ioss::TriShell7::name, "She
   Ioss::ElementTopology::alias(Ioss::TriShell7::name, "Shell_Tri_7_3D");
   Ioss::ElementTopology::alias(Ioss::TriShell7::name, "SHELL_TRIANGLE_7");
   Ioss::ElementTopology::alias(Ioss::TriShell7::name, "SHELL7");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::TriShell7::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::TriPermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::TriShell7::parametric_dimension() const { return 2; }

--- a/packages/seacas/libraries/ioss/src/Ioss_TriShell7.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_TriShell7.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return true; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -44,12 +46,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     TriShell7();
 
   private:
-    static TriShell7 instance_;
-
     TriShell7(const TriShell7 &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Unknown.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Unknown.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Unknown.h>
 #include <cassert> // for assert
@@ -45,6 +46,15 @@ void Ioss::Unknown::factory()
 Ioss::Unknown::Unknown() : Ioss::ElementTopology(Ioss::Unknown::name, Ioss::Unknown::name)
 {
   Ioss::ElementTopology::alias(Ioss::Unknown::name, "invalid_topology");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Unknown::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::NullPermutation::name);
+  assert(perm != nullptr);
+  return perm;
 }
 
 int Ioss::Unknown::parametric_dimension() const { return 0; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Unknown.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Unknown.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     ElementShape shape() const override { return ElementShape::UNKNOWN; }
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -43,12 +45,11 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Unknown();
 
   private:
-    static Unknown instance_;
-
     Unknown(const Unknown &) = delete;
   };
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge12.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge12.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Wedge12.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ void Ioss::Wedge12::factory()
 Ioss::Wedge12::Wedge12() : Ioss::ElementTopology(Ioss::Wedge12::name, "Wedge_12")
 {
   Ioss::ElementTopology::alias(Ioss::Wedge12::name, "Solid_Wedge_12_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Wedge12::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::WedgePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Wedge12::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge12.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge12.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -49,6 +51,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Wedge12();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge15.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge15.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Wedge15.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ void Ioss::Wedge15::factory()
 Ioss::Wedge15::Wedge15() : Ioss::ElementTopology(Ioss::Wedge15::name, "Wedge_15")
 {
   Ioss::ElementTopology::alias(Ioss::Wedge15::name, "Solid_Wedge_15_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Wedge15::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::WedgePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Wedge15::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge15.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge15.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -48,6 +50,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Wedge15();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge16.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge16.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Wedge16.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ void Ioss::Wedge16::factory()
 Ioss::Wedge16::Wedge16() : Ioss::ElementTopology(Ioss::Wedge16::name, "Wedge_16")
 {
   Ioss::ElementTopology::alias(Ioss::Wedge16::name, "Solid_Wedge_16_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Wedge16::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::WedgePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Wedge16::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge16.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge16.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -48,6 +50,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Wedge16();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge18.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge18.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Wedge18.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ void Ioss::Wedge18::factory()
 Ioss::Wedge18::Wedge18() : Ioss::ElementTopology(Ioss::Wedge18::name, "Wedge_18")
 {
   Ioss::ElementTopology::alias(Ioss::Wedge18::name, "Solid_Wedge_18_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Wedge18::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::WedgePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 Ioss::Wedge18::~Wedge18() = default;

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge18.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge18.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -48,6 +50,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Wedge18();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge20.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge20.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Wedge20.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ void Ioss::Wedge20::factory()
 Ioss::Wedge20::Wedge20() : Ioss::ElementTopology(Ioss::Wedge20::name, "Wedge_20")
 {
   Ioss::ElementTopology::alias(Ioss::Wedge20::name, "Solid_Wedge_20_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Wedge20::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::WedgePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Wedge20::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge20.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge20.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -48,6 +50,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Wedge20();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge21.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge21.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Wedge21.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ void Ioss::Wedge21::factory()
 Ioss::Wedge21::Wedge21() : Ioss::ElementTopology(Ioss::Wedge21::name, "Wedge_21")
 {
   Ioss::ElementTopology::alias(Ioss::Wedge21::name, "Solid_Wedge_21_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Wedge21::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::WedgePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Wedge21::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge21.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge21.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -48,6 +50,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Wedge21();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge24.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge24.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Wedge24.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ void Ioss::Wedge24::factory()
 Ioss::Wedge24::Wedge24() : Ioss::ElementTopology(Ioss::Wedge24::name, "Wedge_24")
 {
   Ioss::ElementTopology::alias(Ioss::Wedge24::name, "Solid_Wedge_24_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Wedge24::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::WedgePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Wedge24::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge24.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge24.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -48,6 +50,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Wedge24();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge52.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge52.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Wedge52.h>
 #include <cassert> // for assert
@@ -73,6 +74,16 @@ void Ioss::Wedge52::factory()
 Ioss::Wedge52::Wedge52() : Ioss::ElementTopology(Ioss::Wedge52::name, "Wedge_52")
 {
   Ioss::ElementTopology::alias(Ioss::Wedge52::name, "Solid_Wedge_52_3D");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Wedge52::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::WedgePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Wedge52::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge52.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge52.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -26,6 +27,7 @@ namespace Ioss {
     int          spatial_dimension() const override;
     int          parametric_dimension() const override;
     bool         is_element() const override { return true; }
+    bool         is_shell() const override { return false; }
     int          order() const override;
 
     int number_corner_nodes() const override;
@@ -48,6 +50,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Wedge52();
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge6.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge6.C
@@ -6,6 +6,7 @@
 
 #include "Ioss_CodeTypes.h"           // for IntVector
 #include "Ioss_ElementTopology.h"     // for ElementTopology
+#include "Ioss_ElementPermutation.h" // for ElementPermutation
 #include <Ioss_ElementVariableType.h> // for ElementVariableType
 #include <Ioss_Wedge6.h>
 #include <cassert> // for assert
@@ -74,6 +75,16 @@ Ioss::Wedge6::Wedge6() : Ioss::ElementTopology(Ioss::Wedge6::name, "Wedge_6")
   Ioss::ElementTopology::alias(Ioss::Wedge6::name, "wedge");
   Ioss::ElementTopology::alias(Ioss::Wedge6::name, "Solid_Wedge_6_3D");
   Ioss::ElementTopology::alias(Ioss::Wedge6::name, "WEDGE_6");
+
+  permutation()->alias(get_aliases(Ioss::ElementTopology::name()));
+}
+
+Ioss::ElementPermutation *Ioss::Wedge6::permutation() const
+{
+  auto perm = Ioss::ElementPermutation::factory(Ioss::WedgePermutation::name);
+  assert(perm != nullptr);
+  assert(static_cast<int>(perm->num_permutation_nodes()) == num_corner_nodes());
+  return perm;
 }
 
 int Ioss::Wedge6::parametric_dimension() const { return 3; }

--- a/packages/seacas/libraries/ioss/src/Ioss_Wedge6.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Wedge6.h
@@ -9,6 +9,7 @@
 
 #include <Ioss_CodeTypes.h>       // for IntVector
 #include <Ioss_ElementTopology.h> // for ElementTopology
+#include <Ioss_ElementPermutation.h> // for ElementPermutation
 
 // STL Includes
 
@@ -25,6 +26,7 @@ namespace Ioss {
     int  spatial_dimension() const override;
     int  parametric_dimension() const override;
     bool is_element() const override { return true; }
+    bool is_shell() const override { return false; }
     int  order() const override;
 
     ElementShape shape() const override { return ElementShape::WEDGE; }
@@ -49,6 +51,7 @@ namespace Ioss {
     Ioss::ElementTopology *face_type(int face_number = 0) const override;
     Ioss::ElementTopology *edge_type(int edge_number = 0) const override;
 
+    Ioss::ElementPermutation *permutation() const override;
   protected:
     Wedge6();
 


### PR DESCRIPTION
This is an attempt to extend the element topology classes in IOSS with shell and permutation info.

The permutation implementation which was in Iotm_TextMeshTopologyMapping.h has been moved to it's own Ioss_ElementPermutation class of which every Ioss_ElementTopology class must be able to return an instance depending on the class. This implementation closely follows the singleton pattern of Ioss_ElementTopology and for now, consists a simple factory lookup to return the permutation class. This may be changed to simply store the pointer to the permutation instance on construction of the topology class .... 

There are potentially other ways in which this could have been implemented so I'm curious to hear your review...the second commit shows how I simplified the Iotm_TextMeshTopologyMapping.h header file. The good thing about this is that this now allows a generalized implementation of the SideAdjacency graph for skinning