### PR TITLE
fix gcc error for argument mismatch

### DIFF
--- a/packages/seacas/applications/blot/mscomd.f
+++ b/packages/seacas/applications/blot/mscomd.f
@@ -482,7 +482,7 @@ C         --Set wireframe mode on 1 view
             CALL INIINT (3, 1, LTYP)
             CALL SETMSH (2, 'UNDEFORM', 'NONE', MSHSEL, LTYP,
      &         0, IDUM, 0, IDUM, 'WIREFRAM', ' ', ISSNPS, ISSESS)
-            CALL SCOLOR (.TRUE., CDUM, IDUM, IDUM, RDUM, IDUM,
+            CALL SCOLOR (.TRUE., CDUM, IDUM, [IDUM], [RDUM], [IDUM],
      *        CDUM, SHDCOL, ISHDCL, IDELB)
 
 C         --Set display options


### PR DESCRIPTION
GCC 12 has a new argument mismatch, though they didn't say they changed anything regarding Fortran for porting

I think this fix is okay as those look like dummy arguments but my fortran is very rusty

blot still seems to work
  
   /home/wortiz/.local/opt/seacas/packages/seacas/applications/blot/mscomd.f:948:48:

      485 |             CALL SCOLOR (.TRUE., CDUM, IDUM, IDUM, RDUM, IDUM,
          |                                             2
    ......
      948 |             CALL SCOLOR (.FALSE., INLINE, IFLD, INTYP,
          |                                                1
    Error: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
    /home/wortiz/.local/opt/seacas/packages/seacas/applications/blot/mscomd.f:949:15:

      485 |             CALL SCOLOR (.TRUE., CDUM, IDUM, IDUM, RDUM, IDUM,
          |                                                   2
    ......
      949 |      &         RFIELD, IFIELD, CFIELD, SHDCOL, ISHDCL, IDELB)
          |               1
    Error: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
    /home/wortiz/.local/opt/seacas/packages/seacas/applications/blot/mscomd.f:949:23:

      485 |             CALL SCOLOR (.TRUE., CDUM, IDUM, IDUM, RDUM, IDUM,
          |                                                         2
    ......
      949 |      &         RFIELD, IFIELD, CFIELD, SHDCOL, ISHDCL, IDELB)
          |                       1
    Error: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
    make[2]: *** [packages/seacas/applications/blot/CMakeFiles/blotlib.dir/build.make:2324: packages/seacas/applications/blot/CMakeFiles/blotlib.dir/mscomd.f.o] Error 1
