### PR TITLE
EXODUS.PY: Add context manager functionality to the exodus class

### DIFF
--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -1,5 +1,5 @@
 """
-exodus.py v 1.20.11 (seacas-py3) is a python wrapper of some of the exodus library
+exodus.py v 1.20.12 (seacas-py3) is a python wrapper of some of the exodus library
 (Python 3 Version)
 
 Exodus is a common database for multiple application codes (mesh
@@ -51,7 +51,7 @@ of global variables. Although these examples correspond to typical FE
 applications, the data format is flexible enough to accommodate a
 spectrum of uses.
 
-Copyright(C) 1999-2021 National Technology & Engineering Solutions
+Copyright(C) 1999-2022 National Technology & Engineering Solutions
 of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 NTESS, the U.S. Government retains certain rights in this software.
 
@@ -70,12 +70,12 @@ from enum import Enum
 
 EXODUS_PY_COPYRIGHT_AND_LICENSE = __doc__
 
-EXODUS_PY_VERSION = "1.20.11 (seacas-py3)"
+EXODUS_PY_VERSION = "1.20.12 (seacas-py3)"
 
 EXODUS_PY_COPYRIGHT = """
-You are using exodus.py v 1.20.11 (seacas-py3), a python wrapper of some of the exodus library.
+You are using exodus.py v 1.20.12 (seacas-py3), a python wrapper of some of the exodus library.
 
-Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 National Technology &
+Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 National Technology &
 Engineering Solutions of Sandia, LLC (NTESS).  Under the terms of
 Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
 rights in this software.
@@ -710,6 +710,13 @@ class exodus:
         self.coordsZ = None
         self.times = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+        if not traceback:
+            return True
 
     def summarize(self):
         """

--- a/packages/seacas/scripts/tests/test_exodus3.py
+++ b/packages/seacas/scripts/tests/test_exodus3.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Copyright(C) 1999-2021 National Technology & Engineering Solutions
+Copyright(C) 1999-2022 National Technology & Engineering Solutions
 of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 NTESS, the U.S. Government retains certain rights in this software.
 
@@ -25,12 +25,12 @@ class TestAssemblies(unittest.TestCase):
 
     def setUp(self):
         input_dir = os.path.dirname(__file__)
-        self.exofile = exo.exodus(os.path.join(input_dir, "test-assembly.exo"), mode='r')
         self.tempdir = tempfile.TemporaryDirectory()
         self.temp_exo_path = os.path.join(self.tempdir.name, "temp-test-assembly.exo")
-        self.temp_exofile = self.exofile.copy(self.temp_exo_path, True)
-        self.exofile.close()
-        self.temp_exofile.close()
+        with exo.exodus(os.path.join(input_dir, "test-assembly.exo"), mode='r') as exofile:
+            self.exofile = exofile
+            with self.exofile.copy(self.temp_exo_path, True) as temp_exofile:
+                self.temp_exofile = temp_exofile
 
     def tearDown(self):
         self.tempdir.cleanup()
@@ -47,6 +47,11 @@ class TestAssemblies(unittest.TestCase):
     def test_ex_entity_type_to_objType_wrong_entity_type(self):
         self.assertEqual("EX_INVALID", exo.ex_entity_type_to_objType('fake_entity'))
 
+    def test_exodus_context_manager_reraises_exceptions(self):
+        with self.assertRaises(AssertionError):
+            with exo.exodus(self.temp_exo_path, mode='r') as temp_exofile:
+                self.assertFalse(True)
+
     def test_setup_ex_assembly(self):
         assem = exo.assembly(name='Unit_test', type='EX_ASSEMBLY', id=444)
         assem.entity_list = [100, 222]
@@ -55,37 +60,37 @@ class TestAssemblies(unittest.TestCase):
         self.assertIsInstance(ctype_assem.entity_list, ctypes.POINTER(ctypes.c_longlong))
 
     def test_get_name_assembly(self):
-        temp_exofile = exo.exodus(self.temp_exo_path)
-        assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
-        names = [temp_exofile.get_name("EX_ASSEMBLY", assembly) for assembly in assembly_ids]
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
+            names = [temp_exofile.get_name("EX_ASSEMBLY", assembly) for assembly in assembly_ids]
         self.assertEqual(['Root', 'Child2', 'Child3', 'Child4', 'NewAssembly', 'FromPython'], names)
 
     def test_inquire_assembly(self):
-        temp_exofile = exo.exodus(self.temp_exo_path)
-        assem_count = temp_exofile.inquire("EX_INQ_ASSEMBLY")
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            assem_count = temp_exofile.inquire("EX_INQ_ASSEMBLY")
         self.assertEqual(6, assem_count)
 
     def test_get_block_id_map(self):
-        temp_exofile = exo.exodus(self.temp_exo_path)
-        elem_ids = temp_exofile.get_ids("EX_ELEM_BLOCK")
-        expected = [1, 2, 3, 4, 5, 6, 7]
-        outputs = []
-        for val in elem_ids:
-            outputs.extend(temp_exofile.get_block_id_map("EX_ELEM_BLOCK", val))
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            elem_ids = temp_exofile.get_ids("EX_ELEM_BLOCK")
+            expected = [1, 2, 3, 4, 5, 6, 7]
+            outputs = []
+            for val in elem_ids:
+                outputs.extend(temp_exofile.get_block_id_map("EX_ELEM_BLOCK", val))
         self.assertListEqual(expected, outputs)
 
     def test_get_assembly(self):
-        temp_exofile = exo.exodus(self.temp_exo_path)
-        assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
-        assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
+            assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
         root = exo.assembly(name='Root', type='EX_ASSEMBLY', id=100)
         root.entity_list = [100, 200, 300, 400]
         self.assertEqual(str(root), str(assemblies[0]))
 
     def test_get_assemblies(self):
-        temp_exofile = exo.exodus(self.temp_exo_path)
-        assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
-        assemblies = temp_exofile.get_assemblies(assembly_ids)
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
+            assemblies = temp_exofile.get_assemblies(assembly_ids)
         expected = [exo.assembly(name='Root', type='EX_ASSEMBLY', id=100),
                     exo.assembly(name='Child2', type='EX_ELEM_BLOCK', id=200),
                     exo.assembly(name='Child3', type='EX_ELEM_BLOCK', id=300),
@@ -106,80 +111,72 @@ class TestAssemblies(unittest.TestCase):
     def test_put_assembly(self):
         new = exo.assembly(name='Unit_test', type=exo.ex_entity_type.EX_ASSEMBLY, id=444)
         new.entity_list = [100, 222]
-        temp_exofile = exo.exodus(self.temp_exo_path, mode='a')
-        temp_exofile.put_assembly(new)
-        temp_exofile.close()
-        temp_exofile = exo.exodus(self.temp_exo_path)
-        assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
-        assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
+        with exo.exodus(self.temp_exo_path, mode='a') as temp_exofile:
+            temp_exofile.put_assembly(new)
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
+            assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
         self.assertEqual(new.name, assemblies[6].name)
         self.assertEqual(16, assemblies[6].type)
         self.assertEqual(new.id, assemblies[6].id)
         self.assertEqual(new.entity_list, assemblies[6].entity_list)
 
     def test_get_reduction_variables_assembly(self):
-
-        temp_exofile = exo.exodus(self.temp_exo_path, mode='r')
-        red_var = temp_exofile.get_reduction_variable_number("EX_ASSEMBLY")
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            red_var = temp_exofile.get_reduction_variable_number("EX_ASSEMBLY")
+            names = temp_exofile.get_reduction_variable_names("EX_ASSEMBLY")
         self.assertEqual(4, red_var)
-        names = temp_exofile.get_reduction_variable_names("EX_ASSEMBLY")
         self.assertIn("Momentum_X", names)
         self.assertIn("Momentum_Y", names)
         self.assertIn("Momentum_Z", names)
         self.assertIn("Kinetic_Energy", names)
 
     def test_get_reduction_variables_assembly_enum(self):
-
-        temp_exofile = exo.exodus(self.temp_exo_path, mode='r')
-        red_var = temp_exofile.get_reduction_variable_number(exo.ex_entity_type.EX_ASSEMBLY)
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            red_var = temp_exofile.get_reduction_variable_number(exo.ex_entity_type.EX_ASSEMBLY)
+            names = temp_exofile.get_reduction_variable_names(exo.ex_entity_type.EX_ASSEMBLY)
         self.assertEqual(4, red_var)
-        names = temp_exofile.get_reduction_variable_names(exo.ex_entity_type.EX_ASSEMBLY)
         self.assertIn("Momentum_X", names)
         self.assertIn("Momentum_Y", names)
         self.assertIn("Momentum_Z", names)
         self.assertIn("Kinetic_Energy", names)
 
     def test_get_reduction_variable_assembly(self):
-
-        temp_exofile = exo.exodus(self.temp_exo_path, mode='r')
-        red_var = temp_exofile.get_reduction_variable_number("EX_ASSEMBLY")
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            red_var = temp_exofile.get_reduction_variable_number("EX_ASSEMBLY")
+            name = temp_exofile.get_reduction_variable_name("EX_ASSEMBLY", 1)
         self.assertEqual(4, red_var)
-        name = temp_exofile.get_reduction_variable_name("EX_ASSEMBLY", 1)
         self.assertIn("Momentum_X", name)
 
     def test_get_reduction_variable_assembly_enum(self):
-
-        temp_exofile = exo.exodus(self.temp_exo_path, mode='r')
-        red_var = temp_exofile.get_reduction_variable_number(exo.ex_entity_type.EX_ASSEMBLY)
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            red_var = temp_exofile.get_reduction_variable_number(exo.ex_entity_type.EX_ASSEMBLY)
+            name = temp_exofile.get_reduction_variable_name(exo.ex_entity_type.EX_ASSEMBLY, 1)
         self.assertEqual(4, red_var)
-        name = temp_exofile.get_reduction_variable_name(exo.ex_entity_type.EX_ASSEMBLY, 1)
         self.assertIn("Momentum_X", name)
 
     def test_get_reduction_variable_values_assembly(self):
-
-        temp_exofile = exo.exodus(self.temp_exo_path, mode='r')
-        assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
-        assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
-        values = temp_exofile.get_reduction_variable_values('EX_ASSEMBLY', assemblies[0].id, 1)
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
+            assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
+            values = temp_exofile.get_reduction_variable_values('EX_ASSEMBLY', assemblies[0].id, 1)
         self.assertListEqual([0.02, 0.03, 0.04, 0.05], list(values))
 
     def test_get_reduction_variable_values_assembly_no_values(self):
-
-        temp_exofile = exo.exodus(self.temp_exo_path, mode='r')
-        assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
-        assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
-        values = temp_exofile.get_reduction_variable_values('EX_ASSEMBLY', assemblies[5].id, 1)
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
+            assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
+            values = temp_exofile.get_reduction_variable_values('EX_ASSEMBLY', assemblies[5].id, 1)
         self.assertListEqual([0.00, 0.00, 0.00, 0.00], list(values))
 
     def test_put_assemblies(self):
         new = exo.assembly(name='Unit_test', type='EX_ASSEMBLY', id=444)
         new.entity_list = [100, 222]
-        temp_exofile = exo.exodus(self.temp_exo_path, mode='a')
-        temp_exofile.put_assemblies([new])
-        temp_exofile.close()
-        temp_exofile = exo.exodus(self.temp_exo_path)
-        assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
-        assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
+        with exo.exodus(self.temp_exo_path, mode='a') as temp_exofile:
+            temp_exofile.put_assemblies([new])
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
+            assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
         self.assertEqual(new.name, assemblies[6].name)
         self.assertEqual(16, assemblies[6].type)
         self.assertEqual(new.id, assemblies[6].id)
@@ -190,12 +187,11 @@ class TestAssemblies(unittest.TestCase):
         new.entity_list = [100, 222]
         new2 = exo.assembly(name='Unit_test2', type='EX_ASSEMBLY', id=448)
         new2.entity_list = [102, 224]
-        temp_exofile = exo.exodus(self.temp_exo_path, mode='a')
-        temp_exofile.put_assemblies([new, new2])
-        temp_exofile.close()
-        temp_exofile = exo.exodus(self.temp_exo_path)
-        assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
-        assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
+        with exo.exodus(self.temp_exo_path, mode='a') as temp_exofile:
+            temp_exofile.put_assemblies([new, new2])
+        with exo.exodus(self.temp_exo_path) as temp_exofile:
+            assembly_ids = temp_exofile.get_ids("EX_ASSEMBLY")
+            assemblies = [temp_exofile.get_assembly(assembly) for assembly in assembly_ids]
         self.assertEqual(new.name, assemblies[6].name)
         self.assertEqual(16, assemblies[6].type)
         self.assertEqual(new.id, assemblies[6].id)

--- a/packages/seacas/scripts/tests/test_exodus3.py
+++ b/packages/seacas/scripts/tests/test_exodus3.py
@@ -49,7 +49,7 @@ class TestAssemblies(unittest.TestCase):
 
     def test_exodus_context_manager_reraises_exceptions(self):
         with self.assertRaises(AssertionError):
-            with exo.exodus(self.temp_exo_path, mode='r') as temp_exofile:
+            with exo.exodus(self.temp_exo_path, mode='r'):
                 self.assertFalse(True)
 
     def test_setup_ex_assembly(self):


### PR DESCRIPTION
This will allow the use of with statements for opening and closing
exodus files, including methods which return exodus class objects,
such as exodus.copy.